### PR TITLE
Update docker-compose.yml to remove volume configuration for OSS Redis, as appendonly isn't configured.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,5 +15,3 @@ services:
       restart: always
       ports:
         - "6381:6379"
-      volumes:
-        - ./oss_data:/oss_data


### PR DESCRIPTION
The OSS Redis server started by `docker-compose.yml` doesn't configure an append only file, so the volume configuration for `/data` isn't needed.  This PR removes it.