### PR TITLE
Changed the way that modules are detected to work with Redis Enterprise

### DIFF
--- a/aredis_om/checks.py
+++ b/aredis_om/checks.py
@@ -5,18 +5,19 @@ from aredis_om.connections import get_redis_connection
 
 
 @lru_cache(maxsize=None)
-async def get_modules(conn) -> List[str]:
-    modules = await conn.execute_command("module", "list")
-    return [m[1] for m in modules]
-
+async def check_for_command(conn, cmd):
+    try:
+        cmd_info = await conn.execute_command("command", "info", cmd)
+        return True
+    except TypeError:
+        return False
 
 @lru_cache(maxsize=None)
 async def has_redis_json(conn=None):
     if conn is None:
         conn = get_redis_connection()
-    names = await get_modules(conn)
-    return b"ReJSON" in names or "ReJSON" in names
-
+    command_exists = await check_for_command(conn, "json.set")
+    return command_exists
 
 @lru_cache(maxsize=None)
 async def has_redisearch(conn=None):
@@ -24,5 +25,5 @@ async def has_redisearch(conn=None):
         conn = get_redis_connection()
     if has_redis_json(conn):
         return True
-    names = await get_modules(conn)
-    return b"search" in names or "search" in names
+    command_exists = await check_for_command(conn, "ft.search")
+    return command_exists

--- a/aredis_om/checks.py
+++ b/aredis_om/checks.py
@@ -6,11 +6,8 @@ from aredis_om.connections import get_redis_connection
 
 @lru_cache(maxsize=None)
 async def check_for_command(conn, cmd):
-    try:
-        cmd_info = await conn.execute_command("command", "info", cmd)
-        return True
-    except TypeError:
-        return False
+    cmd_info = await conn.execute_command("command", "info", cmd)
+    return not None in cmd_info
 
 @lru_cache(maxsize=None)
 async def has_redis_json(conn=None):


### PR DESCRIPTION
Using `module list` to determine whether a module is installed wasn't working with Redis Enterprise, changing it to use the `command info ` command.  Closes #73 