### PR TITLE
Adds .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,6 @@ data
 # Sync version of the library, via Unasync
 redis_om/
 tests_sync/
+
+# Apple Files
+.DS_Store


### PR DESCRIPTION
Adds `.DS_Store` to `.gitignore` so that these files don't show as untracked on Apple systems.