### PR TITLE
Updated to RediSearch edge and removed append only configuration as it was spurious

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,13 +2,10 @@ version: "3.8"
 
 services:
   redis:
-    image: "redislabs/redismod:edge"
-    entrypoint: ["redis-server", "--appendonly", "yes", "--loadmodule", "/usr/lib/redis/modules/rejson.so", "--loadmodule", "/usr/lib/redis/modules/redisearch.so"]
+    image: "redislabs/redisearch:edge"
     restart: always
     ports:
       - "6380:6379"
-    volumes:
-      - ./data:/data
 
   oss_redis:
       image: "redis:latest"


### PR DESCRIPTION
This PR updates the container used to RediSearch edge which reduces the amount of configuration needed vs using the RedisMod container.  It also removes the append only configuration as this isn't needed.  

This change also seems to fix the broken test cases?

* Closes #72 
* Closes #66 

Output from running tests:

```bash
$ make test
---------- coverage: platform darwin, python 3.9.5-final-0 -----------
Name                                     Stmts   Miss  Cover   Missing
----------------------------------------------------------------------
aredis_om/__init__.py                        4      0   100%
aredis_om/checks.py                         21     12    43%   9-10, 14-17, 21-26
aredis_om/connections.py                    12      3    75%   20-22
aredis_om/model/__init__.py                  2      0   100%
aredis_om/model/cli/__init__.py              0      0   100%
aredis_om/model/cli/migrate.py              13     13     0%   1-18
aredis_om/model/encoders.py                 72     35    51%   68, 70, 73-86, 94, 96, 98, 132-147, 150-155, 159-173
aredis_om/model/migrations/__init__.py       0      0   100%
aredis_om/model/migrations/migrator.py      84     20    76%   24-35, 49, 70-71, 76-77, 80-83, 94, 105-107, 130-141
aredis_om/model/model.py                   857    118    86%   97, 108, 125, 133, 142-149, 163, 182, 190, 196, 200, 204, 208-211, 215, 238, 242, 294, 302, 348, 388, 395, 413, 440, 468, 493, 496-502, 521, 523, 527, 555-565, 583-586, 597, 644, 658-663, 676, 690, 692, 694, 696, 754, 765, 795, 798-803, 819-829, 879, 902-903, 1047, 1110, 1118, 1122, 1126, 1129, 1145, 1147, 1178-1181, 1261, 1267, 1327-1335, 1349, 1380, 1389-1398, 1402, 1417-1425, 1436-1446, 1459, 1543-1544, 1571-1574, 1658, 1662-1666
aredis_om/model/query_resolver.py           23     23     0%   1-103
aredis_om/model/render_tree.py              33     31     6%   24-75
aredis_om/model/token_escaper.py            13      1    92%   16
aredis_om/unasync_util.py                   20      7    65%   14, 18, 28, 32-34, 41
----------------------------------------------------------------------
TOTAL                                     1154    263    77%

==================================== short test summary info =====================================
FAILED tests_sync/test_oss_redis_features.py::test_all_keys - assert 0 == 3
FAILED tests_sync/test_hash_model.py::test_updates_a_model - redis_om.model.model.NotFoundError
================================= 2 failed, 120 passed in 3.77s ==================================
make: *** [Makefile:66: test] Error 1
...

```

Tests still need a bit of work as 1-2 fail (seems sometimes 1 fails, other times 2...!).