### PR TITLE
Unify other library links with redis/redis-om-dotnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 **Redis OM Python** makes it easy to model Redis data in your Python applications.
 
-**Redis OM Python** | [Redis OM Node.js][redis-om-js] | [Redis OM Spring][redis-om-spring] | [Redis OM .NET][redis-om-dotnet]
+[Redis OM .NET](https://github.com/redis/redis-om-dotnet) | [Redis OM Node.js](https://github.com/redis/redis-om-node) | [Redis OM Spring](https://github.com/redis/redis-om-spring) | **Redis OM Python**
 
 <details>
   <summary><strong>Table of contents</strong></summary>


### PR DESCRIPTION
When browsing through the README, I noticed some of the links were based on an old code location, so I have updated those in this PR, and the PRs linked below for each repo:
redis/redis-om-dotnet#46
redis/redis-om-node#37
redis/redis-om-python/pull/95
redis/redis-om-spring#14