### PR TITLE
Adds delete function at a class level - enables instances of models to be deleted without reading them first

### DIFF
--- a/aredis_om/model/model.py
+++ b/aredis_om/model/model.py
@@ -1114,8 +1114,10 @@ class RedisModel(BaseModel, abc.ABC, metaclass=ModelMeta):
         pk = getattr(self, self._meta.primary_key.field.name)
         return self.make_primary_key(pk)
 
-    async def delete(self):
-        return await self.db().delete(self.key())
+    @classmethod
+    async def delete(cls, pk: Any) -> int:
+        """Delete data at this key."""
+        return await cls.db().delete(cls.make_primary_key(pk))
 
     @classmethod
     async def get(cls, pk: Any) -> "RedisModel":
@@ -1336,10 +1338,6 @@ class HashModel(RedisModel, abc.ABC):
         return result
 
     @classmethod
-    async def delete(cls, pk: Any) -> int:
-        return await cls.db().delete(cls.make_primary_key(pk))
-
-    @classmethod
     @no_type_check
     def _get_value(cls, *args, **kwargs) -> Any:
         """
@@ -1506,10 +1504,6 @@ class JsonModel(RedisModel, abc.ABC):
         if not document:
             raise NotFoundError
         return cls.parse_raw(document)
-
-    @classmethod
-    async def delete(cls, pk: Any) -> int:
-        return await cls.db().delete(cls.make_primary_key(pk))
 
     @classmethod
     def redisearch_schema(cls):

--- a/aredis_om/model/model.py
+++ b/aredis_om/model/model.py
@@ -1336,6 +1336,10 @@ class HashModel(RedisModel, abc.ABC):
         return result
 
     @classmethod
+    async def delete(cls, pk: Any) -> int:
+        return await cls.db().delete(cls.make_primary_key(pk))
+
+    @classmethod
     @no_type_check
     def _get_value(cls, *args, **kwargs) -> Any:
         """
@@ -1502,6 +1506,10 @@ class JsonModel(RedisModel, abc.ABC):
         if not document:
             raise NotFoundError
         return cls.parse_raw(document)
+
+    @classmethod
+    async def delete(cls, pk: Any) -> int:
+        return await cls.db().delete(cls.make_primary_key(pk))
 
     @classmethod
     def redisearch_schema(cls):

--- a/tests/test_hash_model.py
+++ b/tests/test_hash_model.py
@@ -374,6 +374,7 @@ async def test_saves_model_and_creates_pk(m):
     member2 = await m.Member.get(member.pk)
     assert member2 == member
 
+
 @pytest.mark.asyncio
 async def test_delete(m):
     member = m.Member(
@@ -382,7 +383,7 @@ async def test_delete(m):
         email="s@example.com",
         join_date=today,
         age=97,
-        bio="This is a test use to be deleted.",
+        bio="This is a test user to be deleted.",
     )
 
     await member.save()

--- a/tests/test_hash_model.py
+++ b/tests/test_hash_model.py
@@ -374,6 +374,21 @@ async def test_saves_model_and_creates_pk(m):
     member2 = await m.Member.get(member.pk)
     assert member2 == member
 
+@pytest.mark.asyncio
+async def test_delete(m):
+    member = m.Member(
+        first_name="Simon",
+        last_name="Prickett",
+        email="s@example.com",
+        join_date=today,
+        age=97,
+        bio="This is a test use to be deleted.",
+    )
+
+    await member.save()
+    response = await m.Member.delete(member.pk)
+    assert response == 1
+
 
 def test_raises_error_with_embedded_models(m):
     class Address(m.BaseHashModel):

--- a/tests/test_json_model.py
+++ b/tests/test_json_model.py
@@ -186,6 +186,21 @@ async def test_saves_model_and_creates_pk(address, m, redis):
     assert member2 == member
     assert member2.address == address
 
+@pytest.mark.asyncio
+async def test_delete(address, m, redis):
+    member = m.Member(
+        first_name="Simon",
+        last_name="Prickett",
+        email="s@example.com",
+        join_date=today,
+        age=38,
+        address=address,
+    )
+
+    await member.save()
+    response = await m.Member.delete(member.pk)
+    assert response == 1
+
 
 @pytest.mark.asyncio
 async def test_saves_many_implicit_pipeline(address, m):

--- a/tests/test_json_model.py
+++ b/tests/test_json_model.py
@@ -186,6 +186,7 @@ async def test_saves_model_and_creates_pk(address, m, redis):
     assert member2 == member
     assert member2.address == address
 
+
 @pytest.mark.asyncio
 async def test_delete(address, m, redis):
     member = m.Member(


### PR DESCRIPTION
This pull request adds a `delete` function to `HashModel` and `JsonModel` - so you can delete something you know the pk for without first having to read it from Redis.

So you can now do... (where `Person` is a `HashModel` but could be a `JsonModel`):

```python
    Person.delete(pk)
```

before you had to do this:

```python
    person = Person.get(pk)
    person.delete()
```

I've added a couple of tests too.

Closes #127 