### PR TITLE
Updated documentation with note about indexing only being for database 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,9 @@ Customer.find((Customer.last_name == "Brookins") | (
 
 These queries -- and more! -- are possible because **Redis OM manages indexes for you automatically**.
 
-Querying with this index features a rich expression syntax inspired by the Django ORM, SQLAlchemy,  and Peewee. We think you'll enjoy it!
+Querying with this index features a rich expression syntax inspired by the Django ORM, SQLAlchemy, and Peewee. We think you'll enjoy it!
+
+**Note:** Indexing only works for data stored in Redis logical database 0.  If you are using a different database number when connecting to Redis, you can expect the code to raise a `MigrationError` when you run the migrator.
 
 ### Embedded Models
 

--- a/docs/connections.md
+++ b/docs/connections.md
@@ -18,6 +18,8 @@ The default connection is equivalent to the following `REDIS_OM_URL` environment
 
     redis://localhost:6379
 
+**Note:** Indexing only works for data stored in Redis logical database 0.  If you are using a different database number when connecting to Redis, you can expect the code to raise a `MigrationError` when you run the migrator.
+
 ### Passwords and Usernames
 
 Redis can be configured with password protection and a "default" user, in which case you might connect using only the password.
@@ -33,6 +35,8 @@ If your Redis instance requires both a username and a password, you would includ
 ### Database Number
 
 Redis databases are numbered, and the default is 0. You can leave off the database number to use the default database, or specify it.
+
+**Note:** Indexing only works for data stored in Redis logical database 0.  If you are using a different database number when connecting to Redis, you can expect the code to raise a `MigrationError` when you run the migrator.
 
 ### SSL Connections
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -124,6 +124,8 @@ The default connection is equivalent to the following `REDIS_OM_URL` environment
 
 **TIP:** Redis databases are numbered, and the default is 0. You can leave off the database number to use the default database.
 
+**Note:** Indexing only works for data stored in Redis logical database 0.  If you are using a different database number when connecting to Redis, you can expect the code to raise a `MigrationError` when you run the migrator.
+
 Other supported prefixes include "rediss" for SSL connections and "unix" for Unix domain sockets:
 
     rediss://[[username]:[password]]@localhost:6379/0


### PR DESCRIPTION
Updates the documentation to note that indexing only works on database 0 (RediSearch limitation).  Closes #189 