### PR TITLE
Performance improvement for first - avoids unnecessary pagination.

### DIFF
--- a/aredis_om/model/model.py
+++ b/aredis_om/model/model.py
@@ -749,7 +749,7 @@ class FindQuery:
 
     async def first(self):
         query = self.copy(offset=0, limit=1, sort_fields=self.sort_fields)
-        results = await query.execute()
+        results = await query.execute(exhaust_results=False)
         if not results:
             raise NotFoundError()
         return results[0]

--- a/tests/test_hash_model.py
+++ b/tests/test_hash_model.py
@@ -46,7 +46,7 @@ async def m(key_prefix, redis):
         last_name: str = Field(index=True)
         email: str = Field(index=True)
         join_date: datetime.date
-        age: int = Field(index=True)
+        age: int = Field(index=True, sortable=True)
         bio: str = Field(index=True, full_text_search=True)
 
         class Meta:
@@ -357,6 +357,43 @@ def test_validation_passes(m):
     )
     assert member.first_name == "Andrew"
 
+@pytest.mark.asyncio
+async def test_retrieve_first(m):
+    member = m.Member(
+        first_name="Simon",
+        last_name="Prickett",
+        email="s@example.com",
+        join_date=today,
+        age=99,
+        bio="This is the bio field for this user.",
+    )
+
+    await member.save()
+
+    member2 = m.Member(
+        first_name="Another",
+        last_name="Member",
+        email="m@example.com",
+        join_date=today,
+        age=98,
+        bio="This is the bio field for this user.",
+    )
+
+    await member2.save()
+
+    member3 = m.Member(
+        first_name="Third",
+        last_name="Member",
+        email="t@example.com",
+        join_date=today,
+        age=97,
+        bio="This is the bio field for this user.",
+    )
+
+    await member3.save()
+
+    first_one = await m.Member.find().sort_by("age").first()
+    assert first_one == member3
 
 @pytest.mark.asyncio
 async def test_saves_model_and_creates_pk(m):


### PR DESCRIPTION
`first()` was running the `ft.search` query to get the first item, then also paginating the whole dataset unnecessarily.  This PR addresses that by setting `exhaust_results=False` whenever `first` calls `query.execute()`.  This stops the pagination.   Closes #218 and adds a test for `first()` using `HashModel`.