### PR TITLE
Fixes #87

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,11 +37,18 @@ def key_prefix(request, redis):
 
 @pytest.fixture(scope="session", autouse=True)
 def cleanup_keys(request):
-    def cleanup_keys():
-        # Always use the sync Redis connection with finalizer. Setting up an
-        # async finalizer should work, but I'm not suer how yet!
-        from redis_om.connections import get_redis_connection as get_sync_redis
+    # Always use the sync Redis connection with finalizer. Setting up an
+    # async finalizer should work, but I'm not suer how yet!
+    from redis_om.connections import get_redis_connection as get_sync_redis
 
-        _delete_test_keys(TEST_PREFIX, get_sync_redis())
+    # Increment for every pytest-xdist worker
+    redis = get_sync_redis()
+    once_key = f"{TEST_PREFIX}:cleanup_keys"
+    redis.incr(once_key)
 
-    request.addfinalizer(cleanup_keys)
+    yield
+
+    # Delete keys only once
+    if redis.decr(once_key) == 0:
+        _delete_test_keys(TEST_PREFIX, redis)
+        redis.delete(once_key)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,4 +51,3 @@ def cleanup_keys(request):
     # Delete keys only once
     if conn.decr(once_key) == 0:
         _delete_test_keys(TEST_PREFIX, conn)
-        conn.delete(once_key)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,13 +42,13 @@ def cleanup_keys(request):
     from redis_om.connections import get_redis_connection as get_sync_redis
 
     # Increment for every pytest-xdist worker
-    redis = get_sync_redis()
+    conn = get_sync_redis()
     once_key = f"{TEST_PREFIX}:cleanup_keys"
-    redis.incr(once_key)
+    conn.incr(once_key)
 
     yield
 
     # Delete keys only once
-    if redis.decr(once_key) == 0:
-        _delete_test_keys(TEST_PREFIX, redis)
-        redis.delete(once_key)
+    if conn.decr(once_key) == 0:
+        _delete_test_keys(TEST_PREFIX, conn)
+        conn.delete(once_key)

--- a/tests/test_hash_model.py
+++ b/tests/test_hash_model.py
@@ -137,7 +137,7 @@ async def test_full_text_search_queries(members, m):
 
     assert actual == [member1]
 
-    actual = await (m.Member.find(~(m.Member.bio % "anxious")).sort_by('age').all())
+    actual = await (m.Member.find(~(m.Member.bio % "anxious")).sort_by("age").all())
 
     assert actual == [member1, member3]
 

--- a/tests/test_hash_model.py
+++ b/tests/test_hash_model.py
@@ -137,7 +137,7 @@ async def test_full_text_search_queries(members, m):
 
     assert actual == [member1]
 
-    actual = await (m.Member.find(~(m.Member.bio % "anxious")).all())
+    actual = await (m.Member.find(~(m.Member.bio % "anxious")).sort_by('age').all())
 
     assert actual == [member1, member3]
 
@@ -433,7 +433,7 @@ async def test_all_pks(m):
         bio="This is a test user to be deleted.",
     )
 
-    await member1.save()   
+    await member1.save()
 
     pk_list = []
     async for pk in await m.Member.all_pks():


### PR DESCRIPTION
Prevent pytest-xdist workers from stomping on each other in the end in `cleanup_keys` by introducing common "barrier". This change removed nondeterministic tests errors for me.

Fixed ordering in the test `test_full_text_search_queries`, it would occasionally fail for me with 2 item in reverse order.