### PR TITLE
Update the help text in Makefile text to include all options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,9 +14,14 @@ help:
 	@echo "  clean       remove all temporary files"
 	@echo "  lint        run the code linters"
 	@echo "  format      reformat code"
-	@echo "  test        run all the tests"
+	@echo "  test        run all the tests against redislabs/redisearch:edge"
+	@echo "  test_oss    run all the tests against redis:latest"
 	@echo "  shell       open a Poetry shell"
 	@echo "  redis       start a Redis instance with Docker"
+	@echo "  sync        generate modules redis_om, tests_sync from aredis_om, tests respectively"
+	@echo "  dist        build a redis-om package"
+	@echo "  upload      upload a redis-om package to PyPI"
+	@echo "  all         equivalent to \"make lint format test\""
 	@echo ""
 	@echo "Check the Makefile to know exactly what each target is doing."
 
@@ -84,4 +89,4 @@ redis:
 	docker-compose up -d
 
 .PHONY: all
-all: redis $(INSTALL_STAMP) lint test
+all: lint format test


### PR DESCRIPTION
Fixes #80

P.S. Question: Why don't we test against `redis/redis-stack-server:latest` image in docker-compose? In the docs there is a mention of redis stack: https://github.com/redis/redis-om-python/blob/00ed537fcaf43d93ea26e0332d5cb2f1a4c1c4a1/docs/getting_started.md?plain=1#L42
Is it because `redislabs/redisearch` is the minimal sufficient image for RediSearch, RedisJSON?

P.P.S In github actions tests run against `redis/redis-stack:${{ matrix.redisstack }}`.