### PR TITLE
Support time points as numeric indexes

### DIFF
--- a/aredis_om/model/encoders.py
+++ b/aredis_om/model/encoders.py
@@ -50,14 +50,18 @@ def datetime_to_timestamp(t: datetime.datetime) -> int:
 def time_to_timestamp(t: datetime.time) -> int:
     # TODO: Find better / more correct approach!!!!!!!!!!!
     offset = t.utcoffset()
-    offset = math.floor(offset.total_seconds() * 1000) + offset.microseconds // 1000
+    offset_ms = (
+        math.floor(offset.total_seconds() * 1000) + offset.microseconds // 1000
+        if offset is not None
+        else 0
+    )
     return (
         t.hour * 3600 * 1000
         + t.minute * 60 * 1000
         + t.second * 1000
         + t.microsecond // 1000
         # TODO: Find better / more correct approach!!!!!!!!!!!
-        - offset
+        - offset_ms
     )
 
 

--- a/aredis_om/model/encoders.py
+++ b/aredis_om/model/encoders.py
@@ -23,8 +23,11 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
-
+import calendar
+import copy
 import dataclasses
+import datetime
+import math
 from collections import defaultdict
 from enum import Enum
 from pathlib import PurePath
@@ -35,8 +38,28 @@ from pydantic import BaseModel
 from pydantic.json import ENCODERS_BY_TYPE
 
 
+def date_to_timestamp(t: datetime.date) -> int:
+    return calendar.timegm(t.timetuple())
+
+
+def datetime_to_timestamp(t: datetime.datetime) -> int:
+    return math.floor(t.astimezone(datetime.timezone.utc).timestamp() * 1000)
+
+
+def time_to_timestamp(t: datetime.time) -> int:
+    raise NotImplementedError
+
+
 SetIntStr = Set[Union[int, str]]
 DictIntStrAny = Dict[Union[int, str], Any]
+ENCODERS_BY_TYPE_ENHANCED = copy.copy(ENCODERS_BY_TYPE)
+ENCODERS_BY_TYPE_ENHANCED.update(
+    {
+        datetime.date: date_to_timestamp,
+        datetime.datetime: datetime_to_timestamp,
+        datetime.time: time_to_timestamp,
+    }
+)
 
 
 def generate_encoders_by_class_tuples(
@@ -154,8 +177,8 @@ def jsonable_encoder(
                 if isinstance(obj, encoder_type):
                     return encoder(obj)
 
-    if type(obj) in ENCODERS_BY_TYPE:
-        return ENCODERS_BY_TYPE[type(obj)](obj)
+    if type(obj) in ENCODERS_BY_TYPE_ENHANCED:
+        return ENCODERS_BY_TYPE_ENHANCED[type(obj)](obj)
     for encoder, classes_tuple in encoders_by_class_tuples.items():
         if isinstance(obj, classes_tuple):
             return encoder(obj)

--- a/aredis_om/model/encoders.py
+++ b/aredis_om/model/encoders.py
@@ -46,8 +46,19 @@ def datetime_to_timestamp(t: datetime.datetime) -> int:
     return math.floor(t.astimezone(datetime.timezone.utc).timestamp() * 1000)
 
 
+# TODO: Find better / more correct approach!!!!!!!!!!!
 def time_to_timestamp(t: datetime.time) -> int:
-    raise NotImplementedError
+    # TODO: Find better / more correct approach!!!!!!!!!!!
+    offset = t.utcoffset()
+    offset = math.floor(offset.total_seconds() * 1000) + offset.microseconds // 1000
+    return (
+        t.hour * 3600 * 1000
+        + t.minute * 60 * 1000
+        + t.second * 1000
+        + t.microsecond // 1000
+        # TODO: Find better / more correct approach!!!!!!!!!!!
+        - offset
+    )
 
 
 SetIntStr = Set[Union[int, str]]

--- a/aredis_om/model/model.py
+++ b/aredis_om/model/model.py
@@ -40,9 +40,9 @@ from ..checks import has_redis_json, has_redisearch
 from ..connections import get_redis_connection
 from ..unasync_util import ASYNC_MODE
 from .encoders import (
-    jsonable_encoder,
-    datetime_to_timestamp,
     date_to_timestamp,
+    datetime_to_timestamp,
+    jsonable_encoder,
     time_to_timestamp,
 )
 from .render_tree import render_tree

--- a/aredis_om/model/model.py
+++ b/aredis_om/model/model.py
@@ -1,5 +1,6 @@
 import abc
 import dataclasses
+import datetime
 import decimal
 import json
 import logging
@@ -38,7 +39,12 @@ from ulid import ULID
 from ..checks import has_redis_json, has_redisearch
 from ..connections import get_redis_connection
 from ..unasync_util import ASYNC_MODE
-from .encoders import jsonable_encoder
+from .encoders import (
+    jsonable_encoder,
+    datetime_to_timestamp,
+    date_to_timestamp,
+    time_to_timestamp,
+)
 from .render_tree import render_tree
 from .token_escaper import TokenEscaper
 
@@ -330,7 +336,14 @@ class RediSearchFieldTypes(Enum):
 
 
 # TODO: How to handle Geo fields?
-NUMERIC_TYPES = (float, int, decimal.Decimal)
+NUMERIC_TYPES = (
+    float,
+    int,
+    decimal.Decimal,
+    datetime.date,
+    datetime.datetime,
+    datetime.time,
+)
 DEFAULT_PAGE_SIZE = 1000
 
 
@@ -530,6 +543,7 @@ class FindQuery:
                     f"Docs: {ERRORS_URL}#E5"
                 )
         elif field_type is RediSearchFieldTypes.NUMERIC:
+            value = jsonable_encoder(value)
             if op is Operators.EQ:
                 result += f"@{field_name}:[{value} {value}]"
             elif op is Operators.NE:
@@ -1461,6 +1475,13 @@ class HashModel(RedisModel, abc.ABC):
 
 
 class JsonModel(RedisModel, abc.ABC):
+    class Config(RedisModel.Config):
+        json_encoders = {
+            datetime.date: date_to_timestamp,
+            datetime.datetime: datetime_to_timestamp,
+            datetime.time: time_to_timestamp,
+        }
+
     def __init_subclass__(cls, **kwargs):
         # Generate the RediSearch schema once to validate fields.
         cls.redisearch_schema()

--- a/tests/test_hash_model.py
+++ b/tests/test_hash_model.py
@@ -25,6 +25,7 @@ from aredis_om import (
 from redis_om import has_redisearch
 from tests.conftest import py_test_mark_asyncio
 
+
 if not has_redisearch():
     pytestmark = pytest.mark.skip
 

--- a/tests/test_json_model.py
+++ b/tests/test_json_model.py
@@ -437,7 +437,11 @@ async def test_recursive_query_expression_resolution(members, m):
 async def test_recursive_query_field_resolution(members, m):
     member1, _, _ = members
     member1.address.note = m.Note(
-        description="Weird house", created_on=datetime.datetime.now()
+        description="Weird house",
+        created_on=datetime.datetime.now().replace(
+            microsecond=0,
+            tzinfo=datetime.timezone.utc,
+        ),
     )
     await member1.save()
     actual = await m.Member.find(
@@ -449,7 +453,10 @@ async def test_recursive_query_field_resolution(members, m):
         m.Order(
             items=[m.Item(price=10.99, name="Ball")],
             total=10.99,
-            created_on=datetime.datetime.now(),
+            created_on=datetime.datetime.now().replace(
+                microsecond=0,
+                tzinfo=datetime.timezone.utc,
+            ),
         )
     ]
     await member1.save()

--- a/tests/test_json_model.py
+++ b/tests/test_json_model.py
@@ -27,6 +27,7 @@ from aredis_om import (
 from redis_om import has_redis_json
 from tests.conftest import py_test_mark_asyncio
 
+
 if not has_redis_json():
     pytestmark = pytest.mark.skip
 

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -3,6 +3,7 @@ import datetime
 from operator import attrgetter
 
 import pytest_asyncio
+from pydantic import validator
 
 from aredis_om import Field, Migrator, JsonModel, HashModel
 from .conftest import py_test_mark_asyncio
@@ -10,14 +11,14 @@ from .conftest import py_test_mark_asyncio
 
 # TODO: disable tests based on checks
 @pytest_asyncio.fixture(params=[HashModel, JsonModel])
-async def post_model(request, key_prefix):
+async def post_model_datetime(request, key_prefix):
     base_model = request.param
 
-    class BaseJsonModel(base_model, abc.ABC):
+    class BaseModel(base_model, abc.ABC):
         class Meta:
             global_key_prefix = key_prefix
 
-    class Post(BaseJsonModel):
+    class Post(BaseModel):
         created: datetime.datetime = Field(index=True)
 
     await Migrator().run()
@@ -25,7 +26,7 @@ async def post_model(request, key_prefix):
 
 
 @py_test_mark_asyncio
-async def test_time(post_model):
+async def test_datetime(post_model_datetime):
     now = datetime.datetime(1980, 1, 1, hour=2, second=20, tzinfo=datetime.timezone.utc)
     now_p10 = now + datetime.timedelta(seconds=10)
     now_m10 = now - datetime.timedelta(seconds=10)
@@ -34,28 +35,186 @@ async def test_time(post_model):
     now_01_00 = now.replace(hour=3, tzinfo=next_hour_timezone)
     assert now == now_01_00
 
-    posts = [post_model(created=time_point) for time_point in (now, now_p10, now_m10)]
+    posts = [
+        post_model_datetime(created=time_point)
+        for time_point in (now, now_p10, now_m10)
+    ]
     for post in posts:
         await post.save()
 
     expected_sorted_posts = sorted(posts, key=attrgetter("created"))
 
-    assert await post_model.find().sort_by("created").all() == expected_sorted_posts
-    assert await post_model.find(post_model.created == now).all() == [posts[0]]
-    assert await post_model.find(post_model.created == now_01_00).all() == [posts[0]]
+    assert (
+        await post_model_datetime.find().sort_by("created").all()
+        == expected_sorted_posts
+    )
+    assert await post_model_datetime.find(post_model_datetime.created == now).all() == [
+        posts[0]
+    ]
+    assert await post_model_datetime.find(
+        post_model_datetime.created == now_01_00
+    ).all() == [posts[0]]
 
-    post = await post_model.find(post_model.created == now).first()
+    post = await post_model_datetime.find(post_model_datetime.created == now).first()
     assert post.created == now == now_01_00
 
     assert (
-        await post_model.find(post_model.created < now_p10).sort_by("created").all()
+        await post_model_datetime.find(post_model_datetime.created < now_p10)
+        .sort_by("created")
+        .all()
         == expected_sorted_posts[:2]
     )
     assert (
-        await post_model.find(post_model.created < now).sort_by("created").all()
+        await post_model_datetime.find(post_model_datetime.created < now)
+        .sort_by("created")
+        .all()
         == expected_sorted_posts[:1]
     )
     assert (
-        await post_model.find(post_model.created < now_m10).sort_by("created").all()
+        await post_model_datetime.find(post_model_datetime.created < now_m10)
+        .sort_by("created")
+        .all()
+        == []
+    )
+
+
+# TODO: disable tests based on checks
+@pytest_asyncio.fixture(params=[HashModel, JsonModel])
+async def post_model_date(request, key_prefix):
+    base_model = request.param
+
+    class BaseModel(base_model, abc.ABC):
+        class Meta:
+            global_key_prefix = key_prefix
+
+    class Post(BaseModel):
+        created: datetime.date = Field(index=True)
+
+    await Migrator().run()
+    return Post
+
+
+@py_test_mark_asyncio
+async def test_date(post_model_date):
+    now = datetime.date(1980, 1, 2)
+    now_next = now.replace(day=3)
+    now_prev = now.replace(day=1)
+
+    posts = [
+        post_model_date(created=time_point) for time_point in (now, now_next, now_prev)
+    ]
+    for post in posts:
+        await post.save()
+
+    expected_sorted_posts = sorted(posts, key=attrgetter("created"))
+
+    assert (
+        await post_model_date.find().sort_by("created").all() == expected_sorted_posts
+    )
+    assert await post_model_date.find(post_model_date.created == now).all() == [
+        posts[0]
+    ]
+
+    assert (
+        await post_model_date.find(post_model_date.created < now_next)
+        .sort_by("created")
+        .all()
+        == expected_sorted_posts[:2]
+    )
+    assert (
+        await post_model_date.find(post_model_date.created < now)
+        .sort_by("created")
+        .all()
+        == expected_sorted_posts[:1]
+    )
+    assert (
+        await post_model_date.find(post_model_date.created < now_prev)
+        .sort_by("created")
+        .all()
+        == []
+    )
+
+
+# TODO: disable tests based on checks
+@pytest_asyncio.fixture(params=[HashModel, JsonModel])
+async def post_model_time(request, key_prefix):
+    base_model = request.param
+
+    class BaseModel(base_model, abc.ABC):
+        class Meta:
+            global_key_prefix = key_prefix
+
+    class Post(BaseModel):
+        created: datetime.time = Field(index=True)
+
+        # TODO: Find better / more correct approach!!!!!!!!!!
+        # TODO: Provide our field type instead of date datetime.time?
+        # https://pydantic-docs.helpmanual.io/usage/types/#datetime-types
+        # datetime.time is parsing only from time obj or iso? str
+        @validator("created", pre=True, allow_reuse=True)
+        def time_validator(cls, value):
+            if isinstance(value, str):
+                value = int(value)
+            if isinstance(value, int):
+                return datetime.time(
+                    hour=value // 1000 // 3600 % 24,
+                    minute=value // 1000 // 60 % 60,
+                    second=value // 1000 % 60,
+                    microsecond=(value % 1000) * 1000,
+                    tzinfo=datetime.timezone.utc,
+                )
+            return value
+
+    await Migrator().run()
+    return Post
+
+
+@py_test_mark_asyncio
+async def test_time(post_model_time):
+    now = datetime.time(hour=2, second=20, tzinfo=datetime.timezone.utc)
+    now_p10 = now.replace(second=30)
+    now_m10 = now.replace(second=10)
+
+    next_hour_timezone = datetime.timezone(datetime.timedelta(hours=1))
+    now_01_00 = now.replace(hour=3, tzinfo=next_hour_timezone)
+    assert now == now_01_00
+
+    posts = [
+        post_model_time(created=time_point) for time_point in (now, now_p10, now_m10)
+    ]
+    for post in posts:
+        await post.save()
+
+    expected_sorted_posts = sorted(posts, key=attrgetter("created"))
+
+    assert (
+        await post_model_time.find().sort_by("created").all() == expected_sorted_posts
+    )
+    assert await post_model_time.find(post_model_time.created == now).all() == [
+        posts[0]
+    ]
+    assert await post_model_time.find(post_model_time.created == now_01_00).all() == [
+        posts[0]
+    ]
+
+    post = await post_model_time.find(post_model_time.created == now).first()
+    assert post.created == now == now_01_00
+
+    assert (
+        await post_model_time.find(post_model_time.created < now_p10)
+        .sort_by("created")
+        .all()
+        == expected_sorted_posts[:2]
+    )
+    assert (
+        await post_model_time.find(post_model_time.created < now)
+        .sort_by("created")
+        .all()
+        == expected_sorted_posts[:1]
+    )
+    assert (
+        await post_model_time.find(post_model_time.created < now_m10)
+        .sort_by("created")
+        .all()
         == []
     )

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -5,7 +5,8 @@ from operator import attrgetter
 import pytest_asyncio
 from pydantic import validator
 
-from aredis_om import Field, Migrator, JsonModel, HashModel
+from aredis_om import Field, HashModel, JsonModel, Migrator
+
 from .conftest import py_test_mark_asyncio
 
 

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -1,0 +1,61 @@
+import abc
+import datetime
+from operator import attrgetter
+
+import pytest_asyncio
+
+from aredis_om import Field, Migrator, JsonModel, HashModel
+from .conftest import py_test_mark_asyncio
+
+
+# TODO: disable tests based on checks
+@pytest_asyncio.fixture(params=[HashModel, JsonModel])
+async def post_model(request, key_prefix):
+    base_model = request.param
+
+    class BaseJsonModel(base_model, abc.ABC):
+        class Meta:
+            global_key_prefix = key_prefix
+
+    class Post(BaseJsonModel):
+        created: datetime.datetime = Field(index=True)
+
+    await Migrator().run()
+    return Post
+
+
+@py_test_mark_asyncio
+async def test_time(post_model):
+    now = datetime.datetime(1980, 1, 1, hour=2, second=20, tzinfo=datetime.timezone.utc)
+    now_p10 = now + datetime.timedelta(seconds=10)
+    now_m10 = now - datetime.timedelta(seconds=10)
+
+    next_hour_timezone = datetime.timezone(datetime.timedelta(hours=1))
+    now_01_00 = now.replace(hour=3, tzinfo=next_hour_timezone)
+    assert now == now_01_00
+
+    posts = [post_model(created=time_point) for time_point in (now, now_p10, now_m10)]
+    for post in posts:
+        await post.save()
+
+    expected_sorted_posts = sorted(posts, key=attrgetter("created"))
+
+    assert await post_model.find().sort_by("created").all() == expected_sorted_posts
+    assert await post_model.find(post_model.created == now).all() == [posts[0]]
+    assert await post_model.find(post_model.created == now_01_00).all() == [posts[0]]
+
+    post = await post_model.find(post_model.created == now).first()
+    assert post.created == now == now_01_00
+
+    assert (
+        await post_model.find(post_model.created < now_p10).sort_by("created").all()
+        == expected_sorted_posts[:2]
+    )
+    assert (
+        await post_model.find(post_model.created < now).sort_by("created").all()
+        == expected_sorted_posts[:1]
+    )
+    assert (
+        await post_model.find(post_model.created < now_m10).sort_by("created").all()
+        == []
+    )


### PR DESCRIPTION
# **This is a rough draft**

## What's is implemented:
* `datetime.datetime` works as numeric index.
* `datetime.date` works as numeric index.
* `datetime.time` works as numeric index (very sketchy, see below).
* Add test for all above for:
  * Saving to Redis, checking if is valid.
  * Finding by less operator in sorted fashion.
  * Saving no-UTC and checking that restored version(UTC) is equal to pre-saving no-UTC value.

## What can be added / improved:
* `datetime.time` custom parsing implementation
* Our type for `datetime.time` because user will have to write parsing(validation) themselves otherwise(see `post_model_time` in tests).
* Support for `datetime.timedelta` (I skipped it for now).
* Documentation.
* More tests.
* **MORE TESTS**(Seriously, I don't think I understand time zones 100%).

## Questions:
* How to store timezone information as numeric field?
   Right now I just convert everything to UTC before saving. (Someone needs to check that)
* **What to do if user did not provide timezone?**
* Do we want to support `Model.find(Model.field < "Thu Sep 25 10:36:28 2003")` or `"2003-09-25T10:49:41.5-03:00"` or any other string in expressions. (Because `pydantic` supports only iso format(I think)). We could use `dateutil`. Or make it optional dependency.
* Precision. To what precision should we save time-points. I implemented milliseconds because:
  * It should be enough
  * `pydantic` parsing support parsing `datetime` from integers ms out of the box.
  * Later I checked `redis-om-node`, and there they support precision to seconds(I'm not sure): https://github.com/redis/redis-om-node#searching-on-dates
* Cross type expression(`Model.datetime < date/time`). Should we support this? Or catch this and raise exception?
* Will Redis at some point add "Timepoint" index field type(like NUMERIC)? (with timezone support). Because that would simplify things.
* I probably forgot thing or 10, will add later

## Problems:
* datetime.time: [pydantic](https://pydantic-docs.helpmanual.io/usage/types/#datetime-types) support parsing only as:
  ```
  time, existing time object
  str, following formats work:
     HH:MM[:SS[.ffffff]][Z or [±]HH[:]MM]]]
  ```
  so no int parsing, very custom logic(probably wrong)

## Sketchy things:
* datetime.time custom parsing implementation

Fixes #199 