### PR TITLE
Updating default page size to 1000 from 10

### DIFF
--- a/aredis_om/model/model.py
+++ b/aredis_om/model/model.py
@@ -754,7 +754,7 @@ class FindQuery:
             raise NotFoundError()
         return results[0]
 
-    async def all(self, batch_size=10):
+    async def all(self, batch_size=DEFAULT_PAGE_SIZE):
         if batch_size != self.page_size:
             query = self.copy(page_size=batch_size, limit=batch_size)
             return await query.execute()


### PR DESCRIPTION
The default page size for `all` is supposed to be 1000 not 10, for performance reasons.  When I changed the constant `DEFAULT_PAGE_SIZE` a while back, I seem to have forgotten to have changed it here.  This fixes that.