### PR TITLE
Allow users to define a new primary key.

### DIFF
--- a/aredis_om/model/model.py
+++ b/aredis_om/model/model.py
@@ -1105,8 +1105,8 @@ class RedisModel(BaseModel, abc.ABC, metaclass=ModelMeta):
         extra = "allow"
 
     def __init__(__pydantic_self__, **data: Any) -> None:
-        super().__init__(**data)
         __pydantic_self__.validate_primary_key()
+        super().__init__(**data)
 
     def __lt__(self, other):
         """Default sort: compare primary key of models."""
@@ -1166,7 +1166,9 @@ class RedisModel(BaseModel, abc.ABC, metaclass=ModelMeta):
                 primary_keys += 1
         if primary_keys == 0:
             raise RedisModelError("You must define a primary key for the model")
-        elif primary_keys > 1:
+        elif primary_keys == 2:
+            cls.__fields__.pop('pk')
+        elif primary_keys > 2:
             raise RedisModelError("You must define only one primary key for a model")
 
     @classmethod

--- a/aredis_om/model/model.py
+++ b/aredis_om/model/model.py
@@ -564,7 +564,7 @@ class FindQuery:
                     )
                     return ""
                 if isinstance(value, int):
-                    # This if will hit only if the field is prinary key of type int
+                    # This if will hit only if the field is a primary key of type int
                     result = f"@{field_name}:[{value} {value}]"
                 elif separator_char in value:
                     # The value contains the TAG field separator. We can work

--- a/aredis_om/model/model.py
+++ b/aredis_om/model/model.py
@@ -1110,7 +1110,7 @@ class RedisModel(BaseModel, abc.ABC, metaclass=ModelMeta):
 
     def __lt__(self, other):
         """Default sort: compare primary key of models."""
-        return self.pk < other.pk
+        return self.key() < other.key()
 
     def key(self):
         """Return the Redis key for this model."""
@@ -1149,7 +1149,7 @@ class RedisModel(BaseModel, abc.ABC, metaclass=ModelMeta):
         db = self._get_db(pipeline)
 
         # TODO: Wrap any Redis response errors in a custom exception?
-        await db.expire(self.make_primary_key(self.pk), num_seconds)
+        await db.expire(self.make_primary_key(self.key()), num_seconds)
 
     @validator("pk", always=True, allow_reuse=True)
     def validate_pk(cls, v):
@@ -1274,7 +1274,7 @@ class RedisModel(BaseModel, abc.ABC, metaclass=ModelMeta):
         db = cls._get_db(pipeline)
 
         for chunk in ichunked(models, 100):
-            pks = [cls.make_primary_key(model.pk) for model in chunk]
+            pks = [cls.make_primary_key(model.key()) for model in chunk]
             await cls._delete(db, *pks)
 
         return len(models)

--- a/aredis_om/model/model.py
+++ b/aredis_om/model/model.py
@@ -1149,7 +1149,7 @@ class RedisModel(BaseModel, abc.ABC, metaclass=ModelMeta):
         db = self._get_db(pipeline)
 
         # TODO: Wrap any Redis response errors in a custom exception?
-        await db.expire(self.make_primary_key(self.key()), num_seconds)
+        await db.expire(self.key(), num_seconds)
 
     @validator("pk", always=True, allow_reuse=True)
     def validate_pk(cls, v):
@@ -1274,7 +1274,7 @@ class RedisModel(BaseModel, abc.ABC, metaclass=ModelMeta):
         db = cls._get_db(pipeline)
 
         for chunk in ichunked(models, 100):
-            pks = [cls.make_primary_key(model.key()) for model in chunk]
+            pks = [model.key() for model in chunk]
             await cls._delete(db, *pks)
 
         return len(models)

--- a/aredis_om/model/model.py
+++ b/aredis_om/model/model.py
@@ -563,7 +563,10 @@ class FindQuery:
                         separator_char,
                     )
                     return ""
-                if separator_char in value:
+                if isinstance(value, int):
+                    # This if will hit only if the field is prinary key of type int
+                    result = f"@{field_name}:[{value} {value}]"
+                elif separator_char in value:
                     # The value contains the TAG field separator. We can work
                     # around this by breaking apart the values and unioning them
                     # with multiple field:{} queries.

--- a/tests/test_hash_model.py
+++ b/tests/test_hash_model.py
@@ -46,7 +46,7 @@ async def m(key_prefix, redis):
         created_on: datetime.datetime
 
     class Member(BaseHashModel):
-        id: int = Field(index=True)
+        id: int = Field(index=True, primary_key=True)
         first_name: str = Field(index=True)
         last_name: str = Field(index=True)
         email: str = Field(index=True)
@@ -445,7 +445,7 @@ async def test_saves_model_and_creates_pk(m):
     # Save a model instance to Redis
     await member.save()
 
-    member2 = await m.Member.get(member.pk)
+    member2 = await m.Member.get(pk=member.id)
     assert member2 == member
 
 
@@ -495,7 +495,7 @@ async def test_delete(m):
     )
 
     await member.save()
-    response = await m.Member.delete(member.pk)
+    response = await m.Member.delete(pk=member.id)
     assert response == 1
 
 
@@ -588,8 +588,8 @@ async def test_saves_many(m):
     result = await m.Member.add(members)
     assert result == [member1, member2]
 
-    assert await m.Member.get(pk=member1.pk) == member1
-    assert await m.Member.get(pk=member2.pk) == member2
+    assert await m.Member.get(pk=member1.id) == member1
+    assert await m.Member.get(pk=member2.id) == member2
 
 
 @py_test_mark_asyncio
@@ -618,14 +618,14 @@ async def test_delete_many(m):
     result = await m.Member.delete_many(members)
     assert result == 2
     with pytest.raises(NotFoundError):
-        await m.Member.get(pk=member1.pk)
+        await m.Member.get(pk=member1.id)
 
 
 @py_test_mark_asyncio
 async def test_updates_a_model(members, m):
     member1, member2, member3 = members
     await member1.update(last_name="Smith")
-    member = await m.Member.get(member1.pk)
+    member = await m.Member.get(member1.id)
     assert member.last_name == "Smith"
 
 

--- a/tests/test_hash_model.py
+++ b/tests/test_hash_model.py
@@ -618,7 +618,7 @@ async def test_delete_many(m):
     result = await m.Member.delete_many(members)
     assert result == 2
     with pytest.raises(NotFoundError):
-        await m.Member.get(pk=member1.id)
+        await m.Member.get(pk=member1.key())
 
 
 @py_test_mark_asyncio


### PR DESCRIPTION
Related to #251

Only 2 tests cases failed:

```sh
=========================== short test summary info ============================
FAILED tests/test_hash_model.py::test_exact_match_queries - TypeError: argume...
FAILED tests_sync/test_hash_model.py::test_exact_match_queries - TypeError: a...
======================== 2 failed, 140 passed in 3.36s =========================
```

There could be another bug in the code when querying a primary key field of type int:

```python
actual = await m.Member.find(m.Member.id == 0).all()

               if separator_char in value: # a bug here, value is int.
```

@dvora-h, any idea?

FYI, this PR is an enhancement on the `HashModel`, after merging this PR when all tests pass, users can now define a new primary key like:

```python
class Customer(HashModel):
    id: int = Field(primary_key=True)
    first_name: str
    last_name: str
    email: EmailStr
    join_date: datetime.date
    age: int
    bio: Optional[str]
```

If it is not defined, it will take the default one:

```python
    pk: Optional[str] = Field(default=None, primary_key=True)
```

Otherwise, `pk` will be removed, and you can access the new primary key using the `key` method.

Edit:

For some reason, a primary key can't be indexed with an integer value, that's weird, Anyone knows why? Is this a thing in Redis?

Edit:

Found the bug, when the value is integer and the field is primary key, the field type become `RediSearchFieldTypes.TAG` rather than a `RediSearchFieldTypes.NUMERIC`. To solve this issue, we can add an additional if statement within the this if statement `elif field_type is RediSearchFieldTypes.TAG:`:

```python
                if isinstance(value, int):
                    result = f"@{field_name}:[{value} {value}]"
```

Let's see if the tests pass this way.