### PR TITLE
Fix None instance when querying

### DIFF
--- a/aredis_om/model/model.py
+++ b/aredis_om/model/model.py
@@ -1205,6 +1205,8 @@ class RedisModel(BaseModel, abc.ABC, metaclass=ModelMeta):
         offset = 1  # The first item is the count of total matches.
 
         for i in range(1, len(res), step):
+            if res[i + offset] is None:
+                continue
             fields = dict(
                 zip(
                     map(to_string, res[i + offset][::2]),


### PR DESCRIPTION
**Context**
I have an application that is constantly adding instance into redis with a TTL and another application that reads queries it.

**Bug**
Sometimes, the application that queries gets the following error:

```
  File "/home/worker/.local/lib/python3.10/site-packages/aredis_om/model/model.py", line 760, in all
    return await query.execute()
  File "/home/worker/.local/lib/python3.10/site-packages/aredis_om/model/model.py", line 727, in execute
    results = self.model.from_redis(raw_result)
  File "/home/worker/.local/lib/python3.10/site-packages/aredis_om/model/model.py", line 1204, in from_redis
    map(to_string, res[i + fields_offset][::2]),
TypeError: 'NoneType' object is not subscriptable
```
If this application queries again, the error disappear for a while.

**Reason (?)**
I think that the main problem is the interaction between the TTL and the query. If I examine the `res` variable in this loop: https://github.com/redis/redis-om-python/blob/c6fb00bfc3a32666abf502b003bfb031712e20b9/aredis_om/model/model.py#L1207-L1222

I see that the reason of the exception is that the variable has the following structure:

```
[
    3,
    ':src.model.MySchema:01GBZF2X6NZZQQ8M519J9B0NR9', None,
    ':src.model.MySchema:01GBZF2XSF7EKFB3AEA6EW85P2', ['instance_id', 'e86a35a9-0d5f-409c-a1ca-0d84832d2585', 'status', 'success'],
    ':src.model.MySchema:01GBZF2WHPNDE1K917NJ6TBV5N', ['instance_id', '9f61a920-cc58-4fdc-93c8-6bba872c4132', 'status', 'success'],
]
```
which means trying to access a position in a None.

I'm assuming that the reason of having a None is because the instance has died in the redis database but the key is still in the redis index.
