### PR TITLE
Fixes issue decode_responses is set to True regardless if REDIS_OM_UR…

### DIFF
--- a/aredis_om/connections.py
+++ b/aredis_om/connections.py
@@ -7,13 +7,14 @@ URL = os.environ.get("REDIS_OM_URL", None)
 
 
 def get_redis_connection(**kwargs) -> redis.Redis:
+    # Decode from UTF-8 by default
+    if "decode_responses" not in kwargs:
+        kwargs["decode_responses"] = True
+
     # If someone passed in a 'url' parameter, or specified a REDIS_OM_URL
     # environment variable, we'll create the Redis client from the URL.
     url = kwargs.pop("url", URL)
     if url:
         return redis.Redis.from_url(url, **kwargs)
 
-    # Decode from UTF-8 by default
-    if "decode_responses" not in kwargs:
-        kwargs["decode_responses"] = True
     return redis.Redis(**kwargs)


### PR DESCRIPTION
…L environment variable is set.

Otherwise these warnings pop up when persisting objects:

> Could not parse Redis response. Error was: "keywords must be strings". Probably, the connection is not set to decode responses from bytes. Attempting to decode response using the encoding set on model class (<class 'redis_om.model.model.ModelMeta'>. Encoding: utf-8.

To reproduce:

1. Set "REDIS_OM_URL" environment variable:
```os.environ["REDIS_OM_URL"] = "redis://@localhost:6379"```

2. Copy the model in the example (or whatever you have at hand) and try to do a "get", e.g:

```
>>> res = o.get('63176e6c-1a8e-40ca-a2ce-d36fcd823009')
Could not parse Redis response. Error was: "keywords must be strings". Probably, the connection is not set to decode responses from bytes. Attempting to decode response using the encoding set on model class (<class 'redis_om.model.model.ModelMeta'>. Encoding: utf-8.
```

"res" still correctly gets the record data, but the warnings are annoying.
