### PR TITLE
Drop python 3.6 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        pyver: [ "3.6", "3.7", "3.8", "3.9", "3.10", "pypy-3.8", "pypy-3.7" ]
+        pyver: ["3.7", "3.8", "3.9", "3.10", "pypy-3.8", "pypy-3.7" ]
         redisstack: [ "latest" ]
       fail-fast: false
     services:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ classifiers = [
     "Topic :: Database",
     'License :: OSI Approved :: BSD License',
     'Programming Language :: Python :: 3.10',
-    'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',


### PR DESCRIPTION
This PR aligns OM with redis-py. As redis-py starting in 4.4 now removes support for Python 3.6, as promised, this aligns OM.