### PR TITLE
fix: add slash in DEFAULT_ESCAPED_CHARS (#312)

### DIFF
--- a/aredis_om/model/token_escaper.py
+++ b/aredis_om/model/token_escaper.py
@@ -9,7 +9,7 @@ class TokenEscaper:
 
     # Characters that RediSearch requires us to escape during queries.
     # Source: https://redis.io/docs/stack/search/reference/escaping/#the-rules-of-text-field-tokenization
-    DEFAULT_ESCAPED_CHARS = r"[,.<>{}\[\]\\\"\':;!@#$%^&*()\-+=~\ ]"
+    DEFAULT_ESCAPED_CHARS = r"[,.<>{}\[\]\\\"\':;!@#$%^&*()\-+=~\/ ]"
 
     def __init__(self, escape_chars_re: Optional[Pattern] = None):
         if escape_chars_re:


### PR DESCRIPTION
Add slash(`/`) in `DEFAULT_ESCAPED_CHARS` to fix #312.