### PR TITLE
Removing superfluous dependency used in release process

### DIFF
--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Set Poetry config
         run: |
-          pip install --upgrade pip python poetry
+          pip install --upgrade pip poetry
           poetry config virtualenvs.in-project false
           poetry config virtualenvs.path ~/.virtualenvs
           poetry export --dev --without-hashes -o requirements.txt


### PR DESCRIPTION
Removing a useless dependency that caused the release to fail. It was a dependency on a non-existent package named python.