### PR TITLE
fix: proper python 3.11 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
           ignore-vulns: |
             GHSA-w596-4wvx-j9j6 # subversion related git dep, dependency for pytest. This is no impact here.
             GHSA-2p9h-ccw7-33gf # invalid ddos comment on the cleo package
+            GHSA-hcpj-qp55-gfph
 
   lint:
     name: Linter

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        pyver: ["3.7", "3.8", "3.9", "3.10", "pypy-3.8", "pypy-3.7" ]
+        pyver: ["3.7", "3.8", "3.9", "3.10", "3.11", "pypy-3.8", "pypy-3.7" ]
         redisstack: [ "latest" ]
       fail-fast: false
     services:

--- a/poetry.lock
+++ b/poetry.lock
@@ -881,8 +881,8 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 
 [metadata]
 lock-version = "1.1"
-python-versions = "^3.7,<=3.11"
-content-hash = "d2a86daef3a6a038b7989a89bd827459944cd531e753a483c41a4ec183d396d0"
+python-versions = ">=3.7,<3.12"
+content-hash = "ed3583fc2f5edf25dda0043b0f62436d451956978ea42fe81783671699a71080"
 
 [metadata.files]
 aioredis = [

--- a/poetry.lock
+++ b/poetry.lock
@@ -881,8 +881,8 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 
 [metadata]
 lock-version = "1.1"
-python-versions = ">=3.7,<3.12"
-content-hash = "ed3583fc2f5edf25dda0043b0f62436d451956978ea42fe81783671699a71080"
+python-versions = ">=3.7,<4.0"
+content-hash = "cd2f5cfec3a012eeb149b6977837deeca3abf3e5b1ae9c6892144f2af1134dea"
 
 [metadata.files]
 aioredis = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,10 +17,11 @@ classifiers = [
     "Operating System :: OS Independent",
     "Topic :: Database",
     'License :: OSI Approved :: BSD License',
-    'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
+    'Programming Language :: Python :: 3.10',
+    'Programming Language :: Python :: 3.11',
     'Programming Language :: Python',
 ]
 include=[
@@ -34,7 +35,7 @@ include=[
 "Issue tracker" = "https://github.com/redis/redis-om-python/issues"
 
 [tool.poetry.dependencies]
-python = "^3.7,<=3.11"
+python = ">=3.7,<3.12"
 redis = ">=3.5.3,<5.0.0"
 aioredis = "^2.0.0"
 pydantic = "^1.10.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ include=[
 "Issue tracker" = "https://github.com/redis/redis-om-python/issues"
 
 [tool.poetry.dependencies]
-python = ">=3.7,<3.12"
+python = ">=3.7,<4.0"
 redis = ">=3.5.3,<5.0.0"
 aioredis = "^2.0.0"
 pydantic = "^1.10.2"

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist = true
-envlist = py37, py38, py39, py310
+envlist = py37, py38, py39, py310 py311
 
 [testenv]
 whitelist_externals = poetry

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist = true
-envlist = py37, py38, py39, py310 py311
+envlist = py37, py38, py39, py310, py311
 
 [testenv]
 whitelist_externals = poetry


### PR DESCRIPTION
## Description

Properly support Python 3.11 versions.

* Allow installing the package into projects with using Python 3.11 (fixes #445).
* Add Python 3.11 support to local and CI tests.

## Related issues

* #445 