### PR TITLE
fix: all_pks() for complex keys

### DIFF
--- a/aredis_om/model/model.py
+++ b/aredis_om/model/model.py
@@ -1350,16 +1350,16 @@ class HashModel(RedisModel, abc.ABC):
     @classmethod
     async def all_pks(cls):  # type: ignore
         key_prefix = cls.make_key(cls._meta.primary_key_pattern.format(pk=""))
-        # TODO: We assume the key ends with the default separator, ":" -- when
+        # TODO: We assume the key contains the default separator, ":" -- when
         #  we make the separator configurable, we need to update this as well.
         #  ... And probably lots of other places ...
         #
         # TODO: Also, we need to decide how we want to handle the lack of
         #  decode_responses=True...
         return (
-            key.split(":")[-1]
+            key.lstrip(key_prefix)
             if isinstance(key, str)
-            else key.decode(cls.Meta.encoding).split(":")[-1]
+            else key.decode(cls.Meta.encoding).lstrip(key_prefix)
             async for key in cls.db().scan_iter(f"{key_prefix}*", _type="HASH")
         )
 
@@ -1521,16 +1521,16 @@ class JsonModel(RedisModel, abc.ABC):
     @classmethod
     async def all_pks(cls):  # type: ignore
         key_prefix = cls.make_key(cls._meta.primary_key_pattern.format(pk=""))
-        # TODO: We assume the key ends with the default separator, ":" -- when
+        # TODO: We assume the key contains the default separator, ":" -- when
         #  we make the separator configurable, we need to update this as well.
         #  ... And probably lots of other places ...
         #
         # TODO: Also, we need to decide how we want to handle the lack of
         #  decode_responses=True...
         return (
-            key.split(":")[-1]
+            key.lstrip(key_prefix)
             if isinstance(key, str)
-            else key.decode(cls.Meta.encoding).split(":")[-1]
+            else key.decode(cls.Meta.encoding).lstrip(key_prefix)
             async for key in cls.db().scan_iter(f"{key_prefix}*", _type="ReJSON-RL")
         )
 

--- a/aredis_om/model/model.py
+++ b/aredis_om/model/model.py
@@ -1357,9 +1357,9 @@ class HashModel(RedisModel, abc.ABC):
         # TODO: Also, we need to decide how we want to handle the lack of
         #  decode_responses=True...
         return (
-            key.lstrip(key_prefix)
+            key.removeprefix(key_prefix)
             if isinstance(key, str)
-            else key.decode(cls.Meta.encoding).lstrip(key_prefix)
+            else key.decode(cls.Meta.encoding).removeprefix(key_prefix)
             async for key in cls.db().scan_iter(f"{key_prefix}*", _type="HASH")
         )
 
@@ -1528,9 +1528,9 @@ class JsonModel(RedisModel, abc.ABC):
         # TODO: Also, we need to decide how we want to handle the lack of
         #  decode_responses=True...
         return (
-            key.lstrip(key_prefix)
+            key.removeprefix(key_prefix)
             if isinstance(key, str)
-            else key.decode(cls.Meta.encoding).lstrip(key_prefix)
+            else key.decode(cls.Meta.encoding).removeprefix(key_prefix)
             async for key in cls.db().scan_iter(f"{key_prefix}*", _type="ReJSON-RL")
         )
 

--- a/aredis_om/model/model.py
+++ b/aredis_om/model/model.py
@@ -155,7 +155,7 @@ def decode_redis_value(
 def remove_prefix(value: str, prefix: str) -> str:
     """Remove a prefix from a string."""
     if value.startswith(prefix):
-        value = value[len(prefix) :]
+        value = value[len(prefix) :]  # noqa: E203
     return value
 
 

--- a/aredis_om/model/model.py
+++ b/aredis_om/model/model.py
@@ -155,7 +155,7 @@ def decode_redis_value(
 def remove_prefix(value: str, prefix: str) -> str:
     """Remove a prefix from a string."""
     if value.startswith(prefix):
-        value = value[len(prefix):]
+        value = value[len(prefix) :]
     return value
 
 

--- a/tests/test_hash_model.py
+++ b/tests/test_hash_model.py
@@ -500,28 +500,27 @@ async def test_all_pks(m):
     async for pk in await m.Member.all_pks():
         pk_list.append(pk)
 
-    assert sorted(pk_list) == ["", "1"]
+    assert sorted(pk_list) == ["0", "1"]
 
 
 @py_test_mark_asyncio
-async def test_all_pks_with_colon_keys():
+async def test_all_pks_with_colon_keys(key_prefix):
     class City(HashModel):
-        id: str = Field(primary_key=True)
         name: str
 
         class Meta:
-            primary_key_pattern = "location"
+            global_key_prefix = key_prefix
             model_key_prefix = "city"
 
     city1 = City(
-        id="ca:on:toronto",
+        pk="ca:on:toronto",
         name="Toronto",
     )
 
     await city1.save()
 
     city2 = City(
-        id="ca:qc:montreal",
+        pk="ca:qc:montreal",
         name="Montreal",
     )
 

--- a/tests/test_hash_model.py
+++ b/tests/test_hash_model.py
@@ -504,7 +504,7 @@ async def test_all_pks(m):
 
 
 @py_test_mark_asyncio
-async def test_all_pks_with_colon_keys(key_prefix):
+async def test_all_pks_with_complex_pks(key_prefix):
     class City(HashModel):
         name: str
 

--- a/tests/test_hash_model.py
+++ b/tests/test_hash_model.py
@@ -500,7 +500,7 @@ async def test_all_pks(m):
     async for pk in await m.Member.all_pks():
         pk_list.append(pk)
 
-    assert sorted(pk_list) == ["0", "1"]
+    assert sorted(pk_list) == ["", "1"]
 
 
 @py_test_mark_asyncio
@@ -528,7 +528,7 @@ async def test_all_pks_with_colon_keys():
     await city2.save()
 
     pk_list = []
-    async for pk in await m.Member.all_pks():
+    async for pk in await City.all_pks():
         pk_list.append(pk)
 
     assert sorted(pk_list) == ["ca:on:toronto", "ca:qc:montreal"]

--- a/tests/test_hash_model.py
+++ b/tests/test_hash_model.py
@@ -500,7 +500,38 @@ async def test_all_pks(m):
     async for pk in await m.Member.all_pks():
         pk_list.append(pk)
 
-    assert len(pk_list) == 2
+    assert sorted(pk_list) == ["0", "1"]
+
+
+@py_test_mark_asyncio
+async def test_all_pks_with_colon_keys():
+    class City(HashModel):
+        id: str = Field(primary_key=True)
+        name: str
+
+        class Meta:
+            primary_key_pattern = "location"
+            model_key_prefix = "city"
+
+    city1 = City(
+        id="ca:on:toronto",
+        name="Toronto",
+    )
+
+    await city1.save()
+
+    city2 = City(
+        id="ca:qc:montreal",
+        name="Montreal",
+    )
+
+    await city2.save()
+
+    pk_list = []
+    async for pk in await m.Member.all_pks():
+        pk_list.append(pk)
+
+    assert sorted(pk_list) == ["ca:on:toronto", "ca:qc:montreal"]
 
 
 @py_test_mark_asyncio

--- a/tests/test_json_model.py
+++ b/tests/test_json_model.py
@@ -222,7 +222,7 @@ async def test_all_pks(address, m, redis):
 
 
 @py_test_mark_asyncio
-async def test_all_pks_with_colon_keys(key_prefix):
+async def test_all_pks_with_complex_pks(key_prefix):
     class City(JsonModel):
         name: str
 

--- a/tests/test_json_model.py
+++ b/tests/test_json_model.py
@@ -218,16 +218,16 @@ async def test_all_pks(address, m, redis):
     async for pk in await m.Member.all_pks():
         pk_list.append(pk)
 
-    assert sorted(pk_list) == sorted(member.pk, member1.pk)
+    assert sorted(pk_list) == sorted([member.pk, member1.pk])
 
 
 @py_test_mark_asyncio
-async def test_all_pks_with_colon_keys():
+async def test_all_pks_with_colon_keys(key_prefix):
     class City(JsonModel):
         name: str
 
         class Meta:
-            primary_key_pattern = "location"
+            global_key_prefix = key_prefix
             model_key_prefix = "city"
 
     city1 = City(

--- a/tests/test_json_model.py
+++ b/tests/test_json_model.py
@@ -218,7 +218,37 @@ async def test_all_pks(address, m, redis):
     async for pk in await m.Member.all_pks():
         pk_list.append(pk)
 
-    assert len(pk_list) == 2
+    assert sorted(pk_list) == sorted(member.pk, member1.pk)
+
+
+@py_test_mark_asyncio
+async def test_all_pks_with_colon_keys():
+    class City(JsonModel):
+        name: str
+
+        class Meta:
+            primary_key_pattern = "location"
+            model_key_prefix = "city"
+
+    city1 = City(
+        pk="ca:on:toronto",
+        name="Toronto",
+    )
+
+    await city1.save()
+
+    city2 = City(
+        pk="ca:qc:montreal",
+        name="Montreal",
+    )
+
+    await city2.save()
+
+    pk_list = []
+    async for pk in await City.all_pks():
+        pk_list.append(pk)
+
+    assert sorted(pk_list) == ["ca:on:toronto", "ca:qc:montreal"]
 
 
 @py_test_mark_asyncio


### PR DESCRIPTION
## Description

`HashModel.all_pks()` and `JsonModel.all_pks()` return only the last part of the Redis key after the last colon (`:`) instead of full key without the global/modal prefixes.

This only makes difference when we use colons in the primary keys. E.g.:
* Global prefix: `location`
* Model prefix: `city`
* Primary key: `ca:qc:montreal`
* Full Redis key: `location:city:ca:qc:montreal`
* **Expected result of `all_pks`**: `ca:qc:montreal`
* **Actual result of `all_pks`**: `montreal`

See related Issue fro details.

## Related issues

* #470 
