### PR TITLE
chore(ci): run tests with correct python version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: .venv
-          key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
+          key: venv-${{ runner.os }}-${{ matrix.pyver }}-${{ hashFiles('**/poetry.lock') }}
         #----------------------------------------------
         # Make sync version of library (redis_om)
         #----------------------------------------------


### PR DESCRIPTION
## Description

Use separate `.venv` cache for each Python version because `poetry install` does put Python executable into the `.venv` directory thus propagating the the version of the first install into other matrix tests.

## Related Issues

* #473 