### PR TITLE
Simplify model_key_prefix default

### DIFF
--- a/aredis_om/model/model.py
+++ b/aredis_om/model/model.py
@@ -1090,9 +1090,7 @@ class ModelMeta(ModelMetaclass):
             )
         if not getattr(new_class._meta, "model_key_prefix", None):
             # Don't look at the base class for this.
-            new_class._meta.model_key_prefix = (
-                f"{new_class.__module__}.{new_class.__name__}"
-            )
+            new_class._meta.model_key_prefix = new_class.__name__
         if not getattr(new_class._meta, "primary_key_pattern", None):
             new_class._meta.primary_key_pattern = getattr(
                 base_meta, "primary_key_pattern", "{pk}"


### PR DESCRIPTION
I'm proposing this change to make sure that the default value for model_key_prefix is useful for non-advanced users.
Currently the model_key_prefix default value includes the modules path, which is inconvinient if the path of the model changes (could be the file name or some parent folder).

This change would make it a bit more similar to how traditional SQL ORM's handle table names, the index name by default would just be :ModelName:
