### PR TITLE
Allow using Pydantic v2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ lint: $(INSTALL_STAMP) dist
 	$(POETRY) run isort --profile=black --lines-after-imports=2 ./tests/ $(NAME) $(SYNC_NAME)
 	$(POETRY) run black ./tests/ $(NAME)
 	$(POETRY) run flake8 --ignore=W503,E501,F401,E731 ./tests/ $(NAME) $(SYNC_NAME)
-	$(POETRY) run mypy ./tests/ $(NAME) $(SYNC_NAME) --ignore-missing-imports
+	$(POETRY) run mypy ./tests/ $(NAME) $(SYNC_NAME) --ignore-missing-imports --exclude _compat\.py$
 	$(POETRY) run bandit -r $(NAME) $(SYNC_NAME) -s B608
 
 .PHONY: format

--- a/aredis_om/_compat.py
+++ b/aredis_om/_compat.py
@@ -1,0 +1,19 @@
+from pydantic.version import VERSION as PYDANTIC_VERSION
+
+
+PYDANTIC_V2 = PYDANTIC_VERSION.startswith("2.")
+
+if PYDANTIC_V2:
+    from pydantic.v1 import BaseModel, validator
+    from pydantic.v1.fields import FieldInfo, ModelField, Undefined, UndefinedType
+    from pydantic.v1.json import ENCODERS_BY_TYPE
+    from pydantic.v1.main import ModelMetaclass, validate_model
+    from pydantic.v1.typing import NoArgAnyCallable
+    from pydantic.v1.utils import Representation
+else:
+    from pydantic import BaseModel, validator
+    from pydantic.fields import FieldInfo, ModelField, Undefined, UndefinedType
+    from pydantic.json import ENCODERS_BY_TYPE
+    from pydantic.main import ModelMetaclass, validate_model
+    from pydantic.typing import NoArgAnyCallable
+    from pydantic.utils import Representation

--- a/aredis_om/model/encoders.py
+++ b/aredis_om/model/encoders.py
@@ -31,8 +31,7 @@ from pathlib import PurePath
 from types import GeneratorType
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
 
-from pydantic import BaseModel
-from pydantic.json import ENCODERS_BY_TYPE
+from .._compat import ENCODERS_BY_TYPE, BaseModel
 
 
 SetIntStr = Set[Union[int, str]]

--- a/aredis_om/model/model.py
+++ b/aredis_om/model/model.py
@@ -25,18 +25,24 @@ from typing import (
 )
 
 from more_itertools import ichunked
-from pydantic import BaseModel, validator
-from pydantic.fields import FieldInfo as PydanticFieldInfo
-from pydantic.fields import ModelField, Undefined, UndefinedType
-from pydantic.main import ModelMetaclass, validate_model
-from pydantic.typing import NoArgAnyCallable
-from pydantic.utils import Representation
 from redis.commands.json.path import Path
 from redis.exceptions import ResponseError
 from typing_extensions import Protocol, get_args, get_origin
 from ulid import ULID
 
 from .. import redis
+from .._compat import BaseModel
+from .._compat import FieldInfo as PydanticFieldInfo
+from .._compat import (
+    ModelField,
+    ModelMetaclass,
+    NoArgAnyCallable,
+    Representation,
+    Undefined,
+    UndefinedType,
+    validate_model,
+    validator,
+)
 from ..checks import has_redis_json, has_redisearch
 from ..connections import get_redis_connection
 from ..util import ASYNC_MODE

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ include=[
 [tool.poetry.dependencies]
 python = ">=3.7,<4.0"
 redis = ">=3.5.3,<5.0.0"
-pydantic = "^1.10.2"
+pydantic = ">=1.10.2,<2.1.0"
 click = "^8.0.1"
 pptree = "^3.1"
 types-redis = ">=3.5.9,<5.0.0"

--- a/tests/_compat.py
+++ b/tests/_compat.py
@@ -1,0 +1,7 @@
+from aredis_om._compat import PYDANTIC_V2
+
+
+if PYDANTIC_V2:
+    from pydantic.v1 import EmailStr, ValidationError
+else:
+    from pydantic.v1 import EmailStr, ValidationError

--- a/tests/test_hash_model.py
+++ b/tests/test_hash_model.py
@@ -10,7 +10,6 @@ from unittest import mock
 
 import pytest
 import pytest_asyncio
-from pydantic import ValidationError
 
 from aredis_om import (
     Field,
@@ -24,6 +23,7 @@ from aredis_om import (
 # We need to run this check as sync code (during tests) even in async mode
 # because we call it in the top-level module scope.
 from redis_om import has_redisearch
+from tests._compat import ValidationError
 
 from .conftest import py_test_mark_asyncio
 
@@ -165,11 +165,11 @@ async def test_delete_non_exist(members, m):
 async def test_full_text_search_queries(members, m):
     member1, member2, member3 = members
 
-    actual = await (m.Member.find(m.Member.bio % "great").all())
+    actual = await m.Member.find(m.Member.bio % "great").all()
 
     assert actual == [member1]
 
-    actual = await (m.Member.find(~(m.Member.bio % "anxious")).sort_by("age").all())
+    actual = await m.Member.find(~(m.Member.bio % "anxious")).sort_by("age").all()
 
     assert actual == [member1, member3]
 
@@ -245,10 +245,10 @@ async def test_tag_queries_punctuation(m):
     )
     await member2.save()
 
-    result = await (m.Member.find(m.Member.first_name == "Andrew, the Michael").first())
+    result = await m.Member.find(m.Member.first_name == "Andrew, the Michael").first()
     assert result == member1
 
-    result = await (m.Member.find(m.Member.last_name == "St. Brookins-on-Pier").first())
+    result = await m.Member.find(m.Member.last_name == "St. Brookins-on-Pier").first()
     assert result == member1
 
     # Notice that when we index and query multiple values that use the internal

--- a/tests/test_json_model.py
+++ b/tests/test_json_model.py
@@ -10,7 +10,6 @@ from unittest import mock
 
 import pytest
 import pytest_asyncio
-from pydantic import ValidationError
 
 from aredis_om import (
     EmbeddedJsonModel,
@@ -25,6 +24,7 @@ from aredis_om import (
 # We need to run this check as sync code (during tests) even in async mode
 # because we call it in the top-level module scope.
 from redis_om import has_redis_json
+from tests._compat import ValidationError
 
 from .conftest import py_test_mark_asyncio
 

--- a/tests/test_oss_redis_features.py
+++ b/tests/test_oss_redis_features.py
@@ -6,9 +6,9 @@ from typing import Optional
 
 import pytest
 import pytest_asyncio
-from pydantic import ValidationError
 
 from aredis_om import HashModel, Migrator, NotFoundError, RedisModelError
+from tests._compat import ValidationError
 
 from .conftest import py_test_mark_asyncio
 

--- a/tests/test_pydantic_integrations.py
+++ b/tests/test_pydantic_integrations.py
@@ -4,9 +4,9 @@ from collections import namedtuple
 
 import pytest
 import pytest_asyncio
-from pydantic import EmailStr, ValidationError
 
 from aredis_om import Field, HashModel, Migrator
+from tests._compat import EmailStr, ValidationError
 
 
 today = datetime.date.today()


### PR DESCRIPTION
The latest version of FastAPI ([v0.100.0](https://github.com/tiangolo/fastapi/releases/tag/0.100.0)) supports Pydantic v2.

- https://docs.pydantic.dev/2.0/

I'd like to use `redis-om-python` with Pydantic v2 while keeping the compatibility.

This PR does:

- Allow using Pydantic v2 (`pydantic = ">=1.10.2,<2.1.0"`)
- Add `_compat.py` file to import proper Pydantic classes, etc. 
  - Do `from pydantic import ...` if Pydantic is v1
  - Do `from pydantic.v1 import ...` if Pydantic is v2 (Note: Pydantic v2 contains v1 in [v1 module](https://github.com/pydantic/pydantic/tree/main/pydantic/v1))

It allows using Pydantic v2 along with `redis-om-python`.
