### PR TITLE
support late creation of DB connection using callable for Meta.database

### DIFF
--- a/aredis_om/__init__.py
+++ b/aredis_om/__init__.py
@@ -8,11 +8,11 @@ from .model.model import (
     FindQuery,
     HashModel,
     JsonModel,
-    VectorFieldOptions,
     KNNExpression,
     NotFoundError,
     QueryNotSupportedError,
     QuerySyntaxError,
     RedisModel,
     RedisModelError,
+    VectorFieldOptions,
 )

--- a/aredis_om/model/__init__.py
+++ b/aredis_om/model/__init__.py
@@ -4,8 +4,8 @@ from .model import (
     Field,
     HashModel,
     JsonModel,
-    VectorFieldOptions,
     KNNExpression,
     NotFoundError,
     RedisModel,
+    VectorFieldOptions,
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,8 @@ import random
 
 import pytest
 
-from aredis_om import get_redis_connection
+from aredis_om import RedisModel, get_redis_connection
+from aredis_om.model.model import DefaultMeta, model_registry
 
 
 TEST_PREFIX = "redis-om:testing"
@@ -59,3 +60,13 @@ def cleanup_keys(request):
     # Delete keys only once
     if conn.decr(once_key) == 0:
         _delete_test_keys(TEST_PREFIX, conn)
+
+
+@pytest.fixture(autouse=True)
+def reset_meta():
+    yield
+    RedisModel.Meta.database = DefaultMeta
+    if hasattr(RedisModel, "_meta"):
+        del RedisModel._meta
+    RedisModel._conn = None
+    model_registry.clear()


### PR DESCRIPTION
Fix for #519:

* When `RedisModel.Meta.database` has not been set, the meta class won't set it. No DB connection is configured or opened.
* When `MyRedisModel.db()` is called, the old behavior is retained: if `MyRedisModel.Meta.database` is set, it'll be used, otherwise `get_redis_connection()` is called.
  * When `MyRedisModel.Meta.database` is a _function object_, it is executed and its return value is returned.
  * Subsequent calls to `MyRedisModel.db()` return the same object.

So now, when your database address is not known at import time, you set `Meta.database` to a function object that fetches that information at runtime, as late as possible (upon DB usage).