### PR TITLE
Bump `pydantic` requirement to < 2.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "redis-om"
-version = "0.2.1"
+version = "0.2.2"
 description = "Object mappings, and more, for Redis."
 authors = ["Redis OSS <oss@redis.com>"]
 maintainers = ["Redis OSS <oss@redis.com>"]
@@ -37,7 +37,7 @@ include=[
 [tool.poetry.dependencies]
 python = ">=3.7,<4.0"
 redis = ">=3.5.3,<5.0.0"
-pydantic = ">=1.10.2,<2.1.0"
+pydantic = ">=1.10.2,<2.2.0"
 click = "^8.0.1"
 types-redis = ">=3.5.9,<5.0.0"
 python-ulid = "^1.0.3"


### PR DESCRIPTION
Resolves #546

Tested with `Pydantic 2.1.1` on a production project.