### PR TITLE
add `default` parametter to `HashModel.get`

### DIFF
--- a/aredis_om/model/model.py
+++ b/aredis_om/model/model.py
@@ -51,6 +51,7 @@ from .render_tree import render_tree
 from .token_escaper import TokenEscaper
 
 
+__INCOMPLETE = object()
 model_registry = {}
 _T = TypeVar("_T")
 Model = TypeVar("Model", bound="RedisModel")
@@ -1532,9 +1533,11 @@ class HashModel(RedisModel, abc.ABC):
         )
 
     @classmethod
-    async def get(cls: Type["Model"], pk: Any) -> "Model":
+    async def get(cls: Type["Model"], pk: Any, default:__INCOMPLETE) -> "Model":
         document = await cls.db().hgetall(cls.make_primary_key(pk))
         if not document:
+            if default is not INCOMPLETE:
+                return default
             raise NotFoundError
         try:
             result = cls.parse_obj(document)


### PR DESCRIPTION
Hi, I added new constant value `__INCOMPLETE` as default value for optional parameters and then added a new optional parameter named `default` to `get` function. When user pass value to `default` parameter (including `None` and `Ellipsis`) then if key not exist it will return default, otherwise it raises `NotFoundError`