### PR TITLE
Drop Python 3.7 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        pyver: ["3.7", "3.8", "3.9", "3.10", "3.11", "pypy-3.8", "pypy-3.9" ]
+        pyver: [ "3.8", "3.9", "3.10", "3.11", "pypy-3.8", "pypy-3.9" ]
         redisstack: [ "latest" ]
       fail-fast: false
     services:

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -6,15 +6,15 @@ This tutorial will walk you through installing Redis OM, creating your first mod
 
 ## Prerequisites
 
-Redis OM requires Python version 3.7 or above and a Redis instance to connect to.
+Redis OM requires Python version 3.8 or above and a Redis instance to connect to.
 
 ## Python
 
-Make sure you are running **Python version 3.7 or higher**:
+Make sure you are running **Python version 3.8 or higher**:
 
 ```
 python --version
-Python 3.7.0
+Python 3.8.0
 ```
 
 If you don't have Python installed, you can download it from [Python.org](https://www.python.org/downloads/), use [pyenv](https://github.com/pyenv/pyenv), or install Python with your operating system's package manager.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ classifiers = [
     "Operating System :: OS Independent",
     "Topic :: Database",
     'License :: OSI Approved :: BSD License',
-    'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
@@ -35,7 +34,7 @@ include=[
 "Issue tracker" = "https://github.com/redis/redis-om-python/issues"
 
 [tool.poetry.dependencies]
-python = ">=3.7,<4.0"
+python = ">=3.8,<4.0"
 redis = ">=3.5.3,<5.0.0"
 pydantic = ">=1.10.2,<2.1.0"
 click = "^8.0.1"


### PR DESCRIPTION
[Python 3.7 has reached its end-of-life (EOL) as of June 2023](https://devguide.python.org/versions/).