### PR TITLE
moving off abandoned toml editor action

### DIFF
--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -20,7 +20,7 @@ jobs:
           echo "::set-output name=VERSION::$realversion"
 
       - name: Set the version for publishing
-        uses: ciiiii/toml-editor@1.0.0
+        uses: sandstromviktor/toml-editor@2.0.0
         with:
           file: "pyproject.toml"
           key: "tool.poetry.version"

--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,5 @@ tests_sync/
 
 # spelling cruft
 *.dic
+
+.idea


### PR DESCRIPTION
ciiiii/toml-editor@1.0.0 - seems to be abandoned, and since the lock file is pointing to a npm registry who's certificate expired, it is failing on the pypi publish action.