### PR TITLE
adding support for boolean checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ sync: $(INSTALL_STAMP)
 lint: $(INSTALL_STAMP) dist
 	$(POETRY) run isort --profile=black --lines-after-imports=2 ./tests/ $(NAME) $(SYNC_NAME)
 	$(POETRY) run black ./tests/ $(NAME)
-	$(POETRY) run flake8 --ignore=W503,E501,F401,E731 ./tests/ $(NAME) $(SYNC_NAME)
+	$(POETRY) run flake8 --ignore=W503,E501,F401,E731,E712 ./tests/ $(NAME) $(SYNC_NAME)
 	$(POETRY) run mypy ./tests/ $(NAME) $(SYNC_NAME) --ignore-missing-imports --exclude migrate.py --exclude _compat\.py$
 	$(POETRY) run bandit -r $(NAME) $(SYNC_NAME) -s B608
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -702,10 +702,10 @@ Customer.find((Customer.last_name == "Brookins") | (
 ) & (Customer.last_name == "Smith")).all()
 ```
 
-### Saving and querying boolean values
+### Saving and querying Boolean values
 
-For historical reasons, saving and querying boolean values is not supported in `HashModels`, however in JSON models,
-you may store and query boolean values using the `==` syntax:
+For historical reasons, saving and querying Boolean values is not supported in `HashModels`, however in JSON models,
+you may store and query Boolean values using the `==` syntax:
 
 ```python
 from redis_om import (

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -702,6 +702,27 @@ Customer.find((Customer.last_name == "Brookins") | (
 ) & (Customer.last_name == "Smith")).all()
 ```
 
+### Saving and querying boolean values
+
+For historical reasons, saving and querying boolean values is not supported in `HashModels`, however in JSON models,
+you may store and query boolean values using the `==` syntax:
+
+```python
+from redis_om import (
+    Field,
+    JsonModel,
+    Migrator
+)
+
+class Demo(JsonModel):
+    b: bool = Field(index=True)
+
+Migrator().run()
+d = Demo(b=True)
+d.save()
+res = Demo.find(Demo.b == True)
+```
+
 ## Calling Other Redis Commands
 
 Sometimes you'll need to run a Redis command directly.  Redis OM supports this through the `db` method on your model's class.  This returns a connected Redis client instance which exposes a function named for each Redis command.  For example, let's perform some basic set operations:

--- a/tests/test_json_model.py
+++ b/tests/test_json_model.py
@@ -971,3 +971,26 @@ async def test_xfix_queries(m):
 
     result = await m.Member.find(m.Member.bio % "*ack*").first()
     assert result.first_name == "Steve"
+
+
+@py_test_mark_asyncio
+async def test_boolean():
+    class Example(JsonModel):
+        b: bool = Field(index=True)
+        d: datetime.date = Field(index=True)
+        name: str = Field(index=True)
+
+    await Migrator().run()
+
+    ex = Example(b=True, name="steve", d=datetime.date.today())
+    exFalse = Example(b=False, name="foo", d=datetime.date.today())
+    await ex.save()
+    await exFalse.save()
+    res = await Example.find(Example.b == True).first()
+    assert res.name == "steve"
+
+    res = await Example.find(Example.b == False).first()
+    assert res.name == "foo"
+
+    res = await Example.find(Example.d == ex.d and Example.b == True).first()
+    assert res.name == ex.name


### PR DESCRIPTION
Adding boolean checks for JSON model only, for some historical reasons we do not encode booleans to `true/false` in hashes, so it will be JSON only. Also, the way the expressions are formed we will not be able to support pure boolean expressions, they'll need to be binary expressions comparing the boolean to `True` or `False`

Resolves #193 #580 #510 #352 