### PR TITLE
fixing issue with breaking typing.Dict in JsonModel

### DIFF
--- a/aredis_om/model/model.py
+++ b/aredis_om/model/model.py
@@ -83,6 +83,8 @@ def get_outer_type(field):
         field.annotation
     ):
         return field.annotation
+    elif not hasattr(field.annotation, "__args__"):
+        return None
     else:
         return field.annotation.__args__[0]
 
@@ -1943,6 +1945,9 @@ class JsonModel(RedisModel, abc.ABC):
 
         for name, field in fields.items():
             _type = get_outer_type(field)
+            if _type is None:
+                continue
+
             if (
                 not isinstance(field, FieldInfo)
                 and hasattr(field, "metadata")


### PR DESCRIPTION
Fixes #613 - issue with pulling schema information out of `typing.Dict`, we don't support indexing `typing.Dict` objects atm, so really just needs to be ignored.