### PR TITLE
kick off type validation before update

### DIFF
--- a/aredis_om/model/model.py
+++ b/aredis_om/model/model.py
@@ -1628,6 +1628,11 @@ class RedisModel(BaseModel, abc.ABC, metaclass=ModelMeta):
             *_, validation_error = validate_model(self.__class__, self.__dict__)
             if validation_error:
                 raise validation_error
+        else:
+            from pydantic import TypeAdapter
+
+            adapter = TypeAdapter(self.__class__)
+            adapter.validate_python(self.__dict__)
 
 
 class HashModel(RedisModel, abc.ABC):

--- a/tests/test_hash_model.py
+++ b/tests/test_hash_model.py
@@ -875,3 +875,22 @@ async def test_xfix_queries(members, m):
 
     result = await m.Member.find(m.Member.bio % "*eat*").first()
     assert result.first_name == "Andrew"
+
+
+@py_test_mark_asyncio
+async def test_update_validation():
+    class TestUpdate(HashModel):
+        name: str
+        age: int
+
+    await Migrator().run()
+    t = TestUpdate(name="steve", age=34)
+    await t.save()
+    update_dict = dict()
+    update_dict["age"] = "cat"
+
+    with pytest.raises(ValidationError):
+        await t.update(**update_dict)
+
+    rematerialized = await TestUpdate.find(TestUpdate.pk == t.pk).first()
+    assert rematerialized.age == 34


### PR DESCRIPTION
Solves #576 - as it stands now, if you call `update` and you have garbage data in the update dict you can break your redis index. This causes the new pydantic v2 type adapter to validate the model prior to sending the update across.