### PR TITLE
fixing None types in hashes

### DIFF
--- a/aredis_om/model/model.py
+++ b/aredis_om/model/model.py
@@ -1680,6 +1680,9 @@ class HashModel(RedisModel, abc.ABC):
         self.check()
         db = self._get_db(pipeline)
         document = jsonable_encoder(self.dict())
+
+        # filter out values which are `None` because they are not valid in a HSET
+        document = {k: v for k, v in document.items() if v is not None}
         # TODO: Wrap any Redis response errors in a custom exception?
         await db.hset(self.key(), mapping=document)
         return self

--- a/tests/test_hash_model.py
+++ b/tests/test_hash_model.py
@@ -875,3 +875,24 @@ async def test_xfix_queries(members, m):
 
     result = await m.Member.find(m.Member.bio % "*eat*").first()
     assert result.first_name == "Andrew"
+
+
+@py_test_mark_asyncio
+async def test_none():
+    class ModelWithNoneDefault(HashModel):
+        test: Optional[str] = Field(index=True, default=None)
+
+    class ModelWithStringDefault(HashModel):
+        test: Optional[str] = Field(index=True, default='None')
+
+    await Migrator().run()
+
+    a = ModelWithNoneDefault(test=None)
+    await a.save()
+    res = await ModelWithNoneDefault.find(ModelWithNoneDefault.pk == a.pk).first()
+    assert res.test is None
+
+    b = ModelWithStringDefault(test=None)
+    await b.save()
+    res = await ModelWithStringDefault.find(ModelWithStringDefault.pk == b.pk).first()
+    assert res.test == 'None'

--- a/tests/test_hash_model.py
+++ b/tests/test_hash_model.py
@@ -883,16 +883,16 @@ async def test_none():
         test: Optional[str] = Field(index=True, default=None)
 
     class ModelWithStringDefault(HashModel):
-        test: Optional[str] = Field(index=True, default='None')
+        test: Optional[str] = Field(index=True, default="None")
 
     await Migrator().run()
 
-    a = ModelWithNoneDefault(test=None)
+    a = ModelWithNoneDefault()
     await a.save()
     res = await ModelWithNoneDefault.find(ModelWithNoneDefault.pk == a.pk).first()
     assert res.test is None
 
-    b = ModelWithStringDefault(test=None)
+    b = ModelWithStringDefault()
     await b.save()
     res = await ModelWithStringDefault.find(ModelWithStringDefault.pk == b.pk).first()
-    assert res.test == 'None'
+    assert res.test == "None"

--- a/tests/test_json_model.py
+++ b/tests/test_json_model.py
@@ -971,3 +971,24 @@ async def test_xfix_queries(m):
 
     result = await m.Member.find(m.Member.bio % "*ack*").first()
     assert result.first_name == "Steve"
+
+
+@py_test_mark_asyncio
+async def test_none():
+    class ModelWithNoneDefault(JsonModel):
+        test: Optional[str] = Field(index=True, default=None)
+
+    class ModelWithStringDefault(JsonModel):
+        test: Optional[str] = Field(index=True, default="None")
+
+    await Migrator().run()
+
+    a = ModelWithNoneDefault()
+    await a.save()
+    res = await ModelWithNoneDefault.find(ModelWithNoneDefault.pk == a.pk).first()
+    assert res.test is None
+
+    b = ModelWithStringDefault()
+    await b.save()
+    res = await ModelWithStringDefault.find(ModelWithStringDefault.pk == b.pk).first()
+    assert res.test == "None"


### PR DESCRIPTION
Was investigating #562  when I discovered to my dismay that `HashModels` now fail if they encounter a `None`. The genesis of this is the`dict` method in pydantic which produced `''` as the default value if the value for a string field was `None`, changed in pydantic 2.x, now it simply returns `None` if no default is specified. Now this wouldn't be a problem except for the fact that redis-py cannot handle a `None` value in `HSET` (fair enough).

Altering the behavior to exclude `None` type from `HSET` command, while still allowing you to define a default value for the field. 

redis-om-py 0.2.x behavior: `None` types in a hash default to `''`

redis-om-py 0.3.0 behavior: `None` type fails in a hash

new behavior: `None` is just `None`