### PR TITLE
fixing schema parsing in json models with non-str pks

### DIFF
--- a/aredis_om/model/model.py
+++ b/aredis_om/model/model.py
@@ -1982,7 +1982,9 @@ class JsonModel(RedisModel, abc.ABC):
                 if issubclass(_type, str):
                     redisearch_field = f"$.{name} AS {name} TAG SEPARATOR {SINGLE_VALUE_TAG_FIELD_SEPARATOR}"
                 else:
-                    redisearch_field = cls.schema_for_type(name, _type, field_info)
+                    redisearch_field = cls.schema_for_type(
+                        json_path, name, "", _type, field_info
+                    )
                 schema_parts.append(redisearch_field)
                 continue
             schema_parts.append(

--- a/tests/test_hash_model.py
+++ b/tests/test_hash_model.py
@@ -898,6 +898,7 @@ async def test_none():
     assert res.test == "None"
 
 
+@py_test_mark_asyncio
 async def test_update_validation():
     class TestUpdate(HashModel):
         name: str

--- a/tests/test_json_model.py
+++ b/tests/test_json_model.py
@@ -1,6 +1,7 @@
 # type: ignore
 
 import abc
+import asyncio
 import dataclasses
 import datetime
 import decimal
@@ -994,8 +995,8 @@ async def test_none():
     assert res.test == "None"
 
 
+@py_test_mark_asyncio
 async def test_update_validation():
-
     class Embedded(EmbeddedJsonModel):
         price: float
         name: str = Field(index=True)
@@ -1025,6 +1026,7 @@ async def test_update_validation():
     assert rematerialized.age == 42
 
 
+@py_test_mark_asyncio
 async def test_model_with_dict():
     class EmbeddedJsonModelWithDict(EmbeddedJsonModel):
         dict: Dict
@@ -1069,3 +1071,15 @@ async def test_boolean():
 
     res = await Example.find(Example.d == ex.d and Example.b == True).first()
     assert res.name == ex.name
+
+
+@py_test_mark_asyncio
+async def test_int_pk():
+    class ModelWithIntPk(JsonModel):
+        my_id: int = Field(index=True, primary_key=True)
+
+    await Migrator().run()
+    await ModelWithIntPk(my_id=42).save()
+
+    m = await ModelWithIntPk.find(ModelWithIntPk.my_id == 42).first()
+    assert m.my_id == 42


### PR DESCRIPTION
Fixes #619 (copy paste issue from hash model for non-str pks),  also adding back a couple of tests that were squashed away from some previous re-bases