### PR TITLE
single page per `page` call

### DIFF
--- a/aredis_om/model/model.py
+++ b/aredis_om/model/model.py
@@ -422,6 +422,7 @@ class FindQuery:
         page_size: int = DEFAULT_PAGE_SIZE,
         sort_fields: Optional[List[str]] = None,
         nocontent: bool = False,
+        single_page: bool = False,
     ):
         if not has_redisearch(model.db()):
             raise RedisModelError(
@@ -437,6 +438,7 @@ class FindQuery:
         self.limit = limit or (self.knn.k if self.knn else DEFAULT_PAGE_SIZE)
         self.page_size = page_size
         self.nocontent = nocontent
+        self.single_page = single_page
 
         if sort_fields:
             self.sort_fields = self.validate_sort_fields(sort_fields)
@@ -916,6 +918,9 @@ class FindQuery:
         if count <= len(results):
             return self._model_cache
 
+        if self.single_page:
+            return self._model_cache
+
         # Transparently (to the user) make subsequent requests to paginate
         # through the results and finally return them all.
         query = self
@@ -948,7 +953,7 @@ class FindQuery:
         return await self.execute()
 
     async def page(self, offset=0, limit=10):
-        return await self.copy(offset=offset, limit=limit).execute()
+        return await self.copy(offset=offset, limit=limit, single_page=True).execute()
 
     def sort_by(self, *fields: str):
         if not fields:

--- a/aredis_om/model/model.py
+++ b/aredis_om/model/model.py
@@ -948,7 +948,9 @@ class FindQuery:
         return await self.execute()
 
     async def page(self, offset=0, limit=10):
-        return await self.copy(offset=offset, limit=limit).execute(exhaust_results=False)
+        return await self.copy(offset=offset, limit=limit).execute(
+            exhaust_results=False
+        )
 
     def sort_by(self, *fields: str):
         if not fields:

--- a/aredis_om/model/model.py
+++ b/aredis_om/model/model.py
@@ -422,7 +422,6 @@ class FindQuery:
         page_size: int = DEFAULT_PAGE_SIZE,
         sort_fields: Optional[List[str]] = None,
         nocontent: bool = False,
-        single_page: bool = False,
     ):
         if not has_redisearch(model.db()):
             raise RedisModelError(
@@ -438,7 +437,6 @@ class FindQuery:
         self.limit = limit or (self.knn.k if self.knn else DEFAULT_PAGE_SIZE)
         self.page_size = page_size
         self.nocontent = nocontent
-        self.single_page = single_page
 
         if sort_fields:
             self.sort_fields = self.validate_sort_fields(sort_fields)
@@ -953,7 +951,7 @@ class FindQuery:
         return await self.execute()
 
     async def page(self, offset=0, limit=10):
-        return await self.copy(offset=offset, limit=limit, single_page=True).execute()
+        return await self.copy(offset=offset, limit=limit).execute(exhaust_results=False)
 
     def sort_by(self, *fields: str):
         if not fields:

--- a/aredis_om/model/model.py
+++ b/aredis_om/model/model.py
@@ -916,9 +916,6 @@ class FindQuery:
         if count <= len(results):
             return self._model_cache
 
-        if self.single_page:
-            return self._model_cache
-
         # Transparently (to the user) make subsequent requests to paginate
         # through the results and finally return them all.
         query = self

--- a/tests/test_hash_model.py
+++ b/tests/test_hash_model.py
@@ -390,7 +390,7 @@ async def test_case_sensitive(members, m):
     member1, member2, member3 = members
 
     actual = await m.Member.find(m.Member.first_name == "Andrew").all()
-    assert actual == [member1, member3]
+    assert set(actual) == {member1, member3}
 
     actual = await m.Member.find(m.Member.first_name == "andrew").all()
     assert actual == []

--- a/tests/test_hash_model.py
+++ b/tests/test_hash_model.py
@@ -389,8 +389,10 @@ async def test_sorting(members, m):
 async def test_case_sensitive(members, m):
     member1, member2, member3 = members
 
-    actual = await m.Member.find(m.Member.first_name == "Andrew").all()
-    assert set(actual) == {member1, member3}
+    actual = await m.Member.find(
+        m.Member.first_name == "Andrew" and m.Member.pk == member1.pk
+    ).all()
+    assert actual == [member1]
 
     actual = await m.Member.find(m.Member.first_name == "andrew").all()
     assert actual == []

--- a/tests/test_hash_model.py
+++ b/tests/test_hash_model.py
@@ -859,13 +859,13 @@ async def test_xfix_queries(members, m):
     member1, member2, member3 = members
 
     result = await m.Member.find(m.Member.first_name.startswith("And")).first()
-    assert result.first_name == "Andrew"
+    assert result.last_name == "Brookins"
 
     result = await m.Member.find(m.Member.last_name.endswith("ins")).first()
-    assert result.first_name == "Andrew"
+    assert result.last_name == "Brookins"
 
     result = await m.Member.find(m.Member.last_name.contains("ook")).first()
-    assert result.first_name == "Andrew"
+    assert result.last_name == "Brookins"
 
     result = await m.Member.find(m.Member.bio % "great*").first()
     assert result.first_name == "Andrew"


### PR DESCRIPTION
Fixes #623 

Atm nothing is stopping the `page` method from fetching the entire result set rather than just a single page at a time. Adding a flag to get `execute` to stop after the first page.