### PR TITLE
Make RedisModel compatible with Pydantic 2.x

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ sync: $(INSTALL_STAMP)
 lint: $(INSTALL_STAMP) dist
 	$(POETRY) run isort --profile=black --lines-after-imports=2 ./tests/ $(NAME) $(SYNC_NAME)
 	$(POETRY) run black ./tests/ $(NAME)
-	$(POETRY) run flake8 --ignore=W503,E501,F401,E731,E712 ./tests/ $(NAME) $(SYNC_NAME)
+	$(POETRY) run flake8 --ignore=E231,E501,E712,E731,F401,W503 ./tests/ $(NAME) $(SYNC_NAME)
 	$(POETRY) run mypy ./tests/ $(NAME) $(SYNC_NAME) --ignore-missing-imports --exclude migrate.py --exclude _compat\.py$
 	$(POETRY) run bandit -r $(NAME) $(SYNC_NAME) -s B608
 

--- a/aredis_om/_compat.py
+++ b/aredis_om/_compat.py
@@ -25,7 +25,7 @@ if PYDANTIC_V2:
     def use_pydantic_2_plus():
         return True
 
-    from pydantic import BaseModel, TypeAdapter
+    from pydantic import BaseModel, ConfigDict, TypeAdapter
     from pydantic import ValidationError as ValidationError
     from pydantic import validator
     from pydantic._internal._model_construction import ModelMetaclass

--- a/aredis_om/_compat.py
+++ b/aredis_om/_compat.py
@@ -25,7 +25,7 @@ if PYDANTIC_V2:
     def use_pydantic_2_plus():
         return True
 
-    from pydantic import BaseModel, ConfigDict, TypeAdapter
+    from pydantic import BaseModel, TypeAdapter
     from pydantic import ValidationError as ValidationError
     from pydantic import validator
     from pydantic._internal._model_construction import ModelMetaclass

--- a/aredis_om/model/model.py
+++ b/aredis_om/model/model.py
@@ -32,7 +32,7 @@ from typing_extensions import Protocol, get_args, get_origin
 from ulid import ULID
 
 from .. import redis
-from .._compat import BaseModel
+from .._compat import PYDANTIC_V2, BaseModel, ConfigDict
 from .._compat import FieldInfo as PydanticFieldInfo
 from .._compat import (
     ModelField,
@@ -1422,10 +1422,16 @@ class RedisModel(BaseModel, abc.ABC, metaclass=ModelMeta):
 
     Meta = DefaultMeta
 
-    class Config:
-        orm_mode = True
-        arbitrary_types_allowed = True
-        extra = "allow"
+    if PYDANTIC_V2:
+        model_config = ConfigDict(
+            from_attributes=True, arbitrary_types_allowed=True, extra="allow"
+        )
+    else:
+
+        class Config:
+            orm_mode = True
+            arbitrary_types_allowed = True
+            extra = "allow"
 
     def __init__(__pydantic_self__, **data: Any) -> None:
         __pydantic_self__.validate_primary_key()
@@ -1657,8 +1663,8 @@ class HashModel(RedisModel, abc.ABC):
                 for typ in (Set, Mapping, List):
                     if isinstance(origin, type) and issubclass(origin, typ):
                         raise RedisModelError(
-                            f"HashModels cannot index set, list,"
-                            f" or mapping fields. Field: {name}"
+                            f"HashModels cannot index set, list, "
+                            f"or mapping fields. Field: {name}"
                         )
                 if isinstance(field_type, type) and issubclass(field_type, RedisModel):
                     raise RedisModelError(
@@ -1678,8 +1684,8 @@ class HashModel(RedisModel, abc.ABC):
                 for typ in (Set, Mapping, List):
                     if issubclass(origin, typ):
                         raise RedisModelError(
-                            f"HashModels cannot index set, list,"
-                            f" or mapping fields. Field: {name}"
+                            f"HashModels cannot index set, list, "
+                            f"or mapping fields. Field: {name}"
                         )
 
             if issubclass(outer_type, RedisModel):

--- a/aredis_om/model/model.py
+++ b/aredis_om/model/model.py
@@ -11,6 +11,7 @@ from typing import (
     AbstractSet,
     Any,
     Callable,
+    ClassVar,
     Dict,
     List,
     Mapping,
@@ -32,7 +33,7 @@ from typing_extensions import Protocol, get_args, get_origin
 from ulid import ULID
 
 from .. import redis
-from .._compat import PYDANTIC_V2, BaseModel, ConfigDict
+from .._compat import PYDANTIC_V2, BaseModel
 from .._compat import FieldInfo as PydanticFieldInfo
 from .._compat import (
     ModelField,
@@ -1419,10 +1420,13 @@ def outer_type_or_annotation(field):
 
 class RedisModel(BaseModel, abc.ABC, metaclass=ModelMeta):
     pk: Optional[str] = Field(default=None, primary_key=True)
+    ConfigDict: ClassVar
 
     Meta = DefaultMeta
 
     if PYDANTIC_V2:
+        from pydantic import ConfigDict
+
         model_config = ConfigDict(
             from_attributes=True, arbitrary_types_allowed=True, extra="allow"
         )

--- a/aredis_om/model/model.py
+++ b/aredis_om/model/model.py
@@ -1643,9 +1643,6 @@ class RedisModel(BaseModel, abc.ABC, metaclass=ModelMeta):
 
     def check(self):
         """Run all validations."""
-        from pydantic.version import VERSION as PYDANTIC_VERSION
-
-        PYDANTIC_V2 = PYDANTIC_VERSION.startswith("2.")
         if not PYDANTIC_V2:
             *_, validation_error = validate_model(self.__class__, self.__dict__)
             if validation_error:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,4 @@
-version: "3.8"
-
+---
 services:
   redis:
     image: "redis/redis-stack:latest"

--- a/docs/models.md
+++ b/docs/models.md
@@ -142,10 +142,11 @@ from redis_om import HashModel
 class Customer(HashModel):
     # ... Fields ...
 
-    class Config:
-        orm_mode = True
-        arbitrary_types_allowed = True
-        extra = "allow"
+    model_config = ConfigDict(
+        from_attributes=True,
+        arbitrary_types_allowed=True,
+        extra="allow",
+    )
 ```
 
 Some features may not work correctly if you change these settings.

--- a/tests/test_json_model.py
+++ b/tests/test_json_model.py
@@ -882,9 +882,23 @@ async def test_schema(m, key_prefix):
     # We need to build the key prefix because it will differ based on whether
     # these tests were copied into the tests_sync folder and unasynce'd.
     key_prefix = m.Member.make_key(m.Member._meta.primary_key_pattern.format(pk=""))
-    assert (
-        m.Member.redisearch_schema()
-        == f"ON JSON PREFIX 1 {key_prefix} SCHEMA $.pk AS pk TAG SEPARATOR | $.first_name AS first_name TAG SEPARATOR | CASESENSITIVE $.last_name AS last_name TAG SEPARATOR | $.email AS email TAG SEPARATOR |  $.age AS age NUMERIC $.bio AS bio TAG SEPARATOR | $.bio AS bio_fts TEXT $.address.pk AS address_pk TAG SEPARATOR | $.address.city AS address_city TAG SEPARATOR | $.address.postal_code AS address_postal_code TAG SEPARATOR | $.address.note.pk AS address_note_pk TAG SEPARATOR | $.address.note.description AS address_note_description TAG SEPARATOR | $.orders[*].pk AS orders_pk TAG SEPARATOR | $.orders[*].items[*].pk AS orders_items_pk TAG SEPARATOR | $.orders[*].items[*].name AS orders_items_name TAG SEPARATOR |"
+    assert m.Member.redisearch_schema() == (
+        f"ON JSON PREFIX 1 {key_prefix} SCHEMA "
+        "$.pk AS pk TAG SEPARATOR | "
+        "$.first_name AS first_name TAG SEPARATOR | CASESENSITIVE "
+        "$.last_name AS last_name TAG SEPARATOR | "
+        "$.email AS email TAG SEPARATOR |  "
+        "$.age AS age NUMERIC "
+        "$.bio AS bio TAG SEPARATOR | "
+        "$.bio AS bio_fts TEXT "
+        "$.address.pk AS address_pk TAG SEPARATOR | "
+        "$.address.city AS address_city TAG SEPARATOR | "
+        "$.address.postal_code AS address_postal_code TAG SEPARATOR | "
+        "$.address.note.pk AS address_note_pk TAG SEPARATOR | "
+        "$.address.note.description AS address_note_description TAG SEPARATOR | "
+        "$.orders[*].pk AS orders_pk TAG SEPARATOR | "
+        "$.orders[*].items[*].pk AS orders_items_pk TAG SEPARATOR | "
+        "$.orders[*].items[*].name AS orders_items_name TAG SEPARATOR |"
     )
 
 


### PR DESCRIPTION
This updates `RedisModel` to use `model_config` with the right parameters (e.g. `from_attributes`) instead of the `Config` class with deprecated attributes (e.g. `orm_mode`) when Pydantic 2.x is installed. It will most likely resolve the warning shown in #612, but not the main issue reported there.

```
UserWarning: Valid config keys have changed in V2: * 'orm_mode' has been renamed to 'from_attributes'
```

I found the above warning while running a FastAPI app in uvicorn within a Python 3.12 virtualenv and the following packages:

```
annotated-types==0.7.0
anyio==4.4.0
certifi==2024.2.2
cffi==1.16.0
click==8.1.7
cryptography==42.0.7
dnspython==2.6.1
email_validator==2.1.1
fastapi==0.111.0
fastapi-cli==0.0.4
h11==0.14.0
hiredis==2.3.2
httpcore==1.0.5
httptools==0.6.1
httpx==0.27.0
idna==3.7
Jinja2==3.1.4
markdown-it-py==3.0.0
MarkupSafe==2.1.5
mdurl==0.1.2
more-itertools==10.2.0
orjson==3.10.3
pycparser==2.22
pydantic==2.7.2
pydantic_core==2.18.3
Pygments==2.18.0
python-dotenv==1.0.1
python-multipart==0.0.9
python-ulid==1.1.0
PyYAML==6.0.1
redis==5.0.4
redis-om==0.3.1
rich==13.7.1
setuptools==69.5.1
shellingham==1.5.4
sniffio==1.3.1
starlette==0.37.2
typer==0.12.3
types-cffi==1.16.0.20240331
types-pyOpenSSL==24.1.0.20240425
types-redis==4.6.0.20240425
types-setuptools==70.0.0.20240524
typing_extensions==4.12.0
ujson==5.10.0
uvicorn==0.30.0
uvloop==0.19.0
watchfiles==0.22.0
websockets==12.0
```

This also fixes a few warnings/issues I encountered while testing my changes with `make format/lint/test`.