### PR TITLE
fixing broken Pydantic v1 regression

### DIFF
--- a/aredis_om/model/encoders.py
+++ b/aredis_om/model/encoders.py
@@ -90,7 +90,7 @@ def jsonable_encoder(
             sqlalchemy_safe=sqlalchemy_safe,
         )
     if dataclasses.is_dataclass(obj):
-        return dataclasses.asdict(obj)  # type: ignore[call-overload]
+        return dataclasses.asdict(obj)  # type: ignore
     if isinstance(obj, Enum):
         return obj.value
     if isinstance(obj, PurePath):

--- a/aredis_om/model/model.py
+++ b/aredis_om/model/model.py
@@ -1432,7 +1432,8 @@ def outer_type_or_annotation(field):
 
 class RedisModel(BaseModel, abc.ABC, metaclass=ModelMeta):
     pk: Optional[str] = Field(default=None, primary_key=True)
-    ConfigDict: ClassVar
+    if PYDANTIC_V2:
+        ConfigDict: ClassVar
 
     Meta = DefaultMeta
 


### PR DESCRIPTION
Fixes #646 - can validate by changing:

```
pydantic = ">=1.10.2,<3.0.0"
```

to

```
pydantic = ">=1.10.2,<2.0.0"
```

in the pyproject.toml and running:

```bash
poetry lock
poetry install
make test
```


 In pydantic v1.x, there are some broken tests which are a result of some of the tests requiring pydantic 2.x types.
 
 I have not added any additional regression testing for it given that pydantic 1.x, it seems to be moving out of support and I don't have a solid way of automating testing of it (poetry doesn't seem to support me specifying which pydantic version to install?), if anyone from the community or @sav-norem or @bsbodden have any good ideas, all ears.