### PR TITLE
fixing issue with inhereted defaults

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        pyver: [ "3.8", "3.9", "3.10", "3.11", "3.12", "pypy-3.8", "pypy-3.9", "pypy-3.10" ]
+        pyver: [ "3.9", "3.10", "3.11", "3.12", "pypy-3.9", "pypy-3.10" ]
         redisstack: [ "latest" ]
       fail-fast: false
     services:

--- a/tests/test_hash_model.py
+++ b/tests/test_hash_model.py
@@ -951,3 +951,26 @@ async def test_literals():
     await item.save()
     rematerialized = await TestLiterals.find(TestLiterals.flavor == "pumpkin").first()
     assert rematerialized.pk == item.pk
+
+
+@py_test_mark_asyncio
+async def test_child_class_expression_proxy():
+    # https://github.com/redis/redis-om-python/issues/669 seeing weird issue with child classes initalizing all their undefined members as ExpressionProxies
+    class Model(HashModel):
+        first_name: str
+        last_name: str
+        age: int = Field(default=18)
+
+    class Child(Model):
+        other_name: str
+        # is_new: bool = Field(default=True)
+
+    await Migrator().run()
+    m = Child(first_name="Steve", last_name="Lorello", other_name="foo")
+    await m.save()
+    print(m.age)
+    assert m.age == 18
+
+    rematerialized = await Child.find(Child.pk == m.pk).first()
+
+    assert rematerialized.age == 18

--- a/tests/test_hash_model.py
+++ b/tests/test_hash_model.py
@@ -960,6 +960,7 @@ async def test_child_class_expression_proxy():
         first_name: str
         last_name: str
         age: int = Field(default=18)
+        bio: Optional[str] = Field(default=None)
 
     class Child(Model):
         other_name: str
@@ -974,3 +975,4 @@ async def test_child_class_expression_proxy():
     rematerialized = await Child.find(Child.pk == m.pk).first()
 
     assert rematerialized.age == 18
+    assert rematerialized.bio is None

--- a/tests/test_json_model.py
+++ b/tests/test_json_model.py
@@ -1167,6 +1167,7 @@ async def test_child_class_expression_proxy():
         first_name: str
         last_name: str
         age: int = Field(default=18)
+        bio: Optional[str] = Field(default=None)
 
     class Child(Model):
         is_new: bool = Field(default=True)
@@ -1181,3 +1182,4 @@ async def test_child_class_expression_proxy():
 
     assert rematerialized.age == 18
     assert rematerialized.age != 19
+    assert rematerialized.bio is None

--- a/tests/test_json_model.py
+++ b/tests/test_json_model.py
@@ -12,6 +12,7 @@ from unittest import mock
 
 import pytest
 import pytest_asyncio
+from more_itertools.more import first
 
 from aredis_om import (
     EmbeddedJsonModel,
@@ -1157,3 +1158,26 @@ async def test_literals():
     await item.save()
     rematerialized = await TestLiterals.find(TestLiterals.flavor == "pumpkin").first()
     assert rematerialized.pk == item.pk
+
+
+@py_test_mark_asyncio
+async def test_child_class_expression_proxy():
+    # https://github.com/redis/redis-om-python/issues/669 seeing weird issue with child classes initalizing all their undefined members as ExpressionProxies
+    class Model(JsonModel):
+        first_name: str
+        last_name: str
+        age: int = Field(default=18)
+
+    class Child(Model):
+        is_new: bool = Field(default=True)
+
+    await Migrator().run()
+    m = Child(first_name="Steve", last_name="Lorello")
+    await m.save()
+    print(m.age)
+    assert m.age == 18
+
+    rematerialized = await Child.find(Child.pk == m.pk).first()
+
+    assert rematerialized.age == 18
+    assert rematerialized.age != 19


### PR DESCRIPTION
Fixes #669 The meta model doesn't seem to want to properly set the defaults of inherited fields in pydantic, this pulls the defaults out of the model and passes them into the initializer.