### PR TITLE
fix typing for python 3.8, fix warning

### DIFF
--- a/aredis_om/model/model.py
+++ b/aredis_om/model/model.py
@@ -1378,12 +1378,14 @@ def outer_type_or_annotation(field: FieldInfo):
 def should_index_field(field_info: Union[FieldInfo, PydanticFieldInfo]) -> bool:
     # for vector, full text search, and sortable fields, we always have to index
     # We could require the user to set index=True, but that would be a breaking change
-    index = getattr(field_info, "index", None) is True
+    _index = getattr(field_info, "index", None)
+
+    index = _index is True
     vector_options = getattr(field_info, "vector_options", None) is not None
     full_text_search = getattr(field_info, "full_text_search", None) is True
     sortable = getattr(field_info, "sortable", None) is True
 
-    if index is False and any([vector_options, full_text_search, sortable]):
+    if _index is False and any([vector_options, full_text_search, sortable]):
         log.warning(
             "Field is marked as index=False, but it is a vector, full text search, or sortable field. "
             "This will be ignored and the field will be indexed.",
@@ -1965,7 +1967,7 @@ class JsonModel(RedisModel, abc.ABC):
         json_path: str,
         name: str,
         name_prefix: str,
-        typ: Union[type[RedisModel], Any],
+        typ: Union[Type[RedisModel], Any],
         field_info: PydanticFieldInfo,
         parent_type: Optional[Any] = None,
     ) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "redis-om"
-version = "1.0.0-beta"
+version = "1.0.1-beta"
 description = "Object mappings, and more, for Redis."
 authors = ["Redis OSS <oss@redis.com>"]
 maintainers = ["Redis OSS <oss@redis.com>"]

--- a/tests/test_knn_expression.py
+++ b/tests/test_knn_expression.py
@@ -1,7 +1,7 @@
 # type: ignore
 import abc
 import struct
-from typing import Optional
+from typing import Optional, Type
 
 import pytest_asyncio
 
@@ -42,7 +42,7 @@ def to_bytes(vectors: list[float]) -> bytes:
 
 
 @py_test_mark_asyncio
-async def test_vector_field(m: type[JsonModel]):
+async def test_vector_field(m: Type[JsonModel]):
     # Create a new instance of the Member model
     vectors = [0.3 for _ in range(DIMENSIONS)]
     member = m(name="seth", embeddings=[vectors])


### PR DESCRIPTION
This fixes this issue with typing in python 3.8: https://github.com/redis/redis-om-python/issues/693

We also noticed we were getting warnings for when `index=False` and a field that requires indexes was set to `False` even if we didn't set `index`. This fixes that as well.