### PR TITLE
fix issue with nested vector fields and python 3.13 issubclass changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        pyver: [ "3.9", "3.10", "3.11", "3.12", "pypy-3.9", "pypy-3.10" ]
+        pyver: [ "3.9", "3.10", "3.11", "3.12", "3.13", "pypy-3.9", "pypy-3.10" ]
         redisstack: [ "latest" ]
       fail-fast: false
     services:

--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,6 @@ tests_sync/
 *.dic
 
 .idea
+
+# version files
+.tool-versions

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true,
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,0 @@
-{
-    "python.testing.unittestEnabled": false,
-    "python.testing.pytestEnabled": true,
-}

--- a/aredis_om/util.py
+++ b/aredis_om/util.py
@@ -1,4 +1,6 @@
+import decimal
 import inspect
+from typing import Any, Type, get_args
 
 
 def is_async_mode() -> bool:
@@ -10,3 +12,27 @@ def is_async_mode() -> bool:
 
 
 ASYNC_MODE = is_async_mode()
+
+NUMERIC_TYPES = (float, int, decimal.Decimal)
+
+
+def is_numeric_type(type_: Type[Any]) -> bool:
+    try:
+        return issubclass(type_, NUMERIC_TYPES)
+    except TypeError:
+        return False
+
+
+def has_numeric_inner_type(type_: Type[Any]) -> bool:
+    """
+    Check if the type has a numeric inner type.
+    """
+    args = get_args(type_)
+
+    if not args:
+        return False
+
+    try:
+        return issubclass(args[0], NUMERIC_TYPES)
+    except TypeError:
+        return False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "redis-om"
-version = "1.0.1-beta"
+version = "1.0.2-beta"
 description = "Object mappings, and more, for Redis."
 authors = ["Redis OSS <oss@redis.com>"]
 maintainers = ["Redis OSS <oss@redis.com>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
+    'Programming Language :: Python :: 3.13',
     'Programming Language :: Python',
 ]
 include=[

--- a/tests/test_hash_model.py
+++ b/tests/test_hash_model.py
@@ -180,15 +180,15 @@ async def test_full_text_search_queries(members, m):
 async def test_pagination_queries(members, m):
     member1, member2, member3 = members
 
-    actual = await m.Member.find(m.Member.last_name == "Brookins").page()
+    actual = await m.Member.find(m.Member.last_name == "Brookins").sort_by("id").page()
 
     assert actual == [member1, member2]
 
-    actual = await m.Member.find().page(1, 1)
+    actual = await m.Member.find().sort_by("id").page(1, 1)
 
     assert actual == [member2]
 
-    actual = await m.Member.find().page(0, 1)
+    actual = await m.Member.find().sort_by("id").page(0, 1)
 
     assert actual == [member1]
 

--- a/tests/test_json_model.py
+++ b/tests/test_json_model.py
@@ -755,7 +755,7 @@ async def test_sorting(members, m):
 async def test_case_sensitive(members, m):
     member1, member2, member3 = members
 
-    actual = await m.Member.find(m.Member.first_name == "Andrew").all()
+    actual = await m.Member.find(m.Member.first_name == "Andrew").sort_by("pk").all()
     assert actual == [member1, member3]
 
     actual = await m.Member.find(m.Member.first_name == "andrew").all()

--- a/tests/test_json_model.py
+++ b/tests/test_json_model.py
@@ -756,7 +756,9 @@ async def test_case_sensitive(members, m):
     member1, member2, member3 = members
 
     actual = await m.Member.find(m.Member.first_name == "Andrew").sort_by("pk").all()
-    assert actual == [member1, member3]
+    assert sorted(actual, key=lambda m: m.pk) == sorted(
+        [member1, member3], key=lambda m: m.pk
+    )
 
     actual = await m.Member.find(m.Member.first_name == "andrew").all()
     assert actual == []

--- a/tests/test_knn_expression.py
+++ b/tests/test_knn_expression.py
@@ -29,7 +29,24 @@ async def m(key_prefix, redis):
 
     class Member(BaseJsonModel, index=True):
         name: str
-        embeddings: list[list[float]] = Field([], vector_options=vector_field_options)
+        embeddings: list[float] = Field([], vector_options=vector_field_options)
+        embeddings_score: Optional[float] = None
+
+    await Migrator().run()
+
+    return Member
+
+
+@pytest_asyncio.fixture
+async def n(key_prefix, redis):
+    class BaseJsonModel(JsonModel, abc.ABC):
+        class Meta:
+            global_key_prefix = key_prefix
+            database = redis
+
+    class Member(BaseJsonModel, index=True):
+        name: str
+        nested: list[list[float]] = Field([], vector_options=vector_field_options)
         embeddings_score: Optional[float] = None
 
     await Migrator().run()
@@ -45,7 +62,7 @@ def to_bytes(vectors: list[float]) -> bytes:
 async def test_vector_field(m: Type[JsonModel]):
     # Create a new instance of the Member model
     vectors = [0.3 for _ in range(DIMENSIONS)]
-    member = m(name="seth", embeddings=[vectors])
+    member = m(name="seth", embeddings=vectors)
 
     # Save the member to Redis
     await member.save()
@@ -58,6 +75,30 @@ async def test_vector_field(m: Type[JsonModel]):
     )
 
     query = m.find(knn=knn)
+
+    members = await query.all()
+
+    assert len(members) == 1
+    assert members[0].embeddings_score is not None
+
+
+@py_test_mark_asyncio
+async def test_nested_vector_field(n: Type[JsonModel]):
+    # Create a new instance of the Member model
+    vectors = [0.3 for _ in range(DIMENSIONS)]
+    member = n(name="seth", nested=[vectors])
+
+    # Save the member to Redis
+    await member.save()
+
+    knn = KNNExpression(
+        k=1,
+        vector_field=n.nested,
+        score_field=n.embeddings_score,
+        reference_vector=to_bytes(vectors),
+    )
+
+    query = n.find(knn=knn)
 
     members = await query.all()
 


### PR DESCRIPTION
The main purpose of this PR is to support python 3.13.

There is a change to `issubclass` where if you feed in a type like `list[float]`, it will raise a type error because it does not validate that the inner types are `float`s and so it now raises an error instead of possibly returning a false positive.

In troubleshooting this, we also came across this PR: https://github.com/redis/redis-om-python/pull/674 from @huwaizatahir2, making this change (and updating the field to be `list[float]` instead of `list[list[float]]` also resolved the issue we were facing.

For backwards compatibility, we still allow `list[list[float]]` but we wanted to also support what is probably the correct way of defining vector fields which is `list[float]`.

We also kept running into the flaky test from `tests/test_hash_model.py::test_pagination_queries` so we went ahead and pulled in the fix from this PR: https://github.com/redis/redis-om-python/pull/694

This PR should now make it possible to use `redis-om` with python 3.13 as well as fix the issues associated with the other 2 PRs tagged above.