### PR TITLE
Fix broken redis.io documentation URLs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -330,9 +330,9 @@ For feature requests, please describe:
 
 ## Additional Resources
 
-- [Redis OM Documentation](https://redis.io/docs/stack/get-started/tutorials/stack-python/)
-- [RediSearch Documentation](https://redis.io/docs/stack/search/)
-- [RedisJSON Documentation](https://redis.io/docs/stack/json/)
+- [Redis OM Documentation](https://redis.io/docs/latest/develop/clients/redis-py/)
+- [RediSearch Documentation](https://redis.io/docs/latest/develop/interact/search-and-query/)
+- [RedisJSON Documentation](https://redis.io/docs/latest/develop/data-types/json/)
 - [Pydantic Documentation](https://docs.pydantic.dev/)
 
 ## Getting Help

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Before writing any code you'll need a Redis instance with the appropriate Redis 
 docker run -p 6379:6379 -p 8001:8001 redis/redis-stack
 ```
 
-This launches the [redis-stack](https://redis.io/docs/stack/) an extension of Redis that adds all manner of modern data structures to Redis. You'll also notice that if you open up http://localhost:8001 you'll have access to the redis-insight GUI, a GUI you can use to visualize and work with your data in Redis.
+This launches the [redis-stack](https://redis.io/docs/latest/) an extension of Redis that adds all manner of modern data structures to Redis. You'll also notice that if you open up http://localhost:8001 you'll have access to the redis-insight GUI, a GUI you can use to visualize and work with your data in Redis.
 
 
 ## 📇 Modeling Your Data
@@ -424,8 +424,8 @@ Redis OM uses the [MIT license][license-url].
 [redis-om-js]: https://github.com/redis-om/redis-om-js
 [redis-om-dotnet]: https://github.com/redis-om/redis-om-dotnet
 [redis-om-spring]: https://github.com/redis-om/redis-om-spring
-[redisearch-url]: https://redis.io/docs/stack/search/
-[redis-json-url]: https://redis.io/docs/stack/json/
+[redisearch-url]: https://redis.io/docs/latest/develop/interact/search-and-query/
+[redis-json-url]: https://redis.io/docs/latest/develop/data-types/json/
 [pydantic-url]: https://github.com/samuelcolvin/pydantic
 [ulid-url]: https://github.com/ulid/spec
 [redis-enterprise-url]: https://redis.com/try-free/

--- a/aredis_om/model/token_escaper.py
+++ b/aredis_om/model/token_escaper.py
@@ -8,7 +8,7 @@ class TokenEscaper:
     """
 
     # Characters that RediSearch requires us to escape during queries.
-    # Source: https://redis.io/docs/stack/search/reference/escaping/#the-rules-of-text-field-tokenization
+    # Source: https://redis.io/docs/latest/develop/interact/search-and-query/advanced-concepts/escaping/
     DEFAULT_ESCAPED_CHARS = r"[,.<>{}\[\]\\\"\':;!@#$%^&*()\-+=~\/ ]"
 
     def __init__(self, escape_chars_re: Optional[Pattern[str]] = None):

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -765,6 +765,6 @@ If you're a FastAPI user, check out [how to integrate Redis OM with FastAPI](htt
 
 <!-- Links -->
 
-[redisearch-url]: https://redis.io/docs/stack/search/
-[redis-json-url]: https://redis.io/docs/stack/json/
+[redisearch-url]: https://redis.io/docs/latest/develop/interact/search-and-query/
+[redis-json-url]: https://redis.io/docs/latest/develop/data-types/json/
 [pydantic-url]: https://github.com/samuelcolvin/pydantic

--- a/docs/redis_modules.md
+++ b/docs/redis_modules.md
@@ -22,8 +22,8 @@ So, what won't work without these modules?
 
 You can use RediSearch and RedisJSON with your self-hosted Redis deployment. Just follow the instructions on installing the binary versions of the modules in their Quick Start Guides:
 
-- [RedisJSON Quick Start - Running Binaries](https://redis.io/docs/stack/json/)
-- [RediSearch Quick Start - Running Binaries](https://redis.io/docs/stack/search/quick_start/)
+- [RedisJSON Quick Start - Running Binaries](https://redis.io/docs/latest/develop/data-types/json/)
+- [RediSearch Quick Start - Running Binaries](https://redis.io/docs/latest/develop/get-started/document-database/)
 
 **NOTE**: Both of these modules' Quick Start Guides also have instructions on how to run the modules in Redis with Docker.
 


### PR DESCRIPTION
The old `redis.io/docs/stack/*` URLs no longer work after Redis reorganized their documentation. This PR updates all broken links to the new URL structure under `redis.io/docs/latest/develop/*`.

## URL Mapping

| Old URL | New URL |
|---------|---------|
| `redis.io/docs/stack/` | `redis.io/docs/latest/` |
| `redis.io/docs/stack/search/` | `redis.io/docs/latest/develop/interact/search-and-query/` |
| `redis.io/docs/stack/json/` | `redis.io/docs/latest/develop/data-types/json/` |
| `redis.io/docs/stack/search/quick_start/` | `redis.io/docs/latest/develop/get-started/document-database/` |
| `redis.io/docs/stack/get-started/tutorials/stack-python/` | `redis.io/docs/latest/develop/clients/redis-py/` |
| `redis.io/docs/stack/search/reference/escaping/` | `redis.io/docs/latest/develop/interact/search-and-query/advanced-concepts/escaping/` |

## Files Changed

- `README.md`
- `docs/getting_started.md`
- `docs/redis_modules.md`
- `CONTRIBUTING.md`
- `aredis_om/model/token_escaper.py`

Closes #717
Closes #738
