### PR TITLE
Include Python version in CI cache key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .venv
-          key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
+          key: venv-${{ runner.os }}-${{ env.pythonversion }}-${{ hashFiles('**/poetry.lock') }}
       - name: Make sync version of library (redis_om)
         run: make sync
         #----------------------------------------------
@@ -120,7 +120,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .venv
-          key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
+          key: venv-${{ runner.os }}-${{ matrix.pyver }}-${{ hashFiles('**/poetry.lock') }}
         #----------------------------------------------
         # Make sync version of library (redis_om)
         #----------------------------------------------


### PR DESCRIPTION
The venv cache key was missing the Python version, causing the same cached venv to be shared across all Python versions (3.9, 3.10, 3.11, 3.12, 3.13, pypy).

This caused failures when a venv built for Python 3.11+ (which doesn't need `async-timeout`) was restored for Python 3.10 (which does need it as a conditional dependency of redis-py 7.x).

Fixes #743
