### PR TITLE
Fix inconsistent .pk behaviour with custom primary keys

### DIFF
--- a/tests/test_hash_model.py
+++ b/tests/test_hash_model.py
@@ -23,6 +23,7 @@ from aredis_om import (
     RedisModel,
     RedisModelError,
 )
+from aredis_om.model.model import ExpressionProxy
 
 # We need to run this check as sync code (during tests) even in async mode
 # because we call it in the top-level module scope.
@@ -1535,3 +1536,36 @@ async def test_optional_bytes_field(key_prefix, redis):
     await a2.save()
     r2 = await Attachment.get(a2.pk)
     assert r2.data == b"\x89PNG\x00\xff"
+
+
+
+@py_test_mark_asyncio
+async def test_custom_primary_key_pk_property(key_prefix, redis):
+    """Test that .pk returns the actual value when using a custom primary key.
+
+    Regression test for GitHub issue #570: accessing .pk on a model with
+    custom primary_key=True returned an ExpressionProxy instead of the value.
+    """
+
+    class ModelWithCustomPK(HashModel, index=True):
+        x: int = Field(primary_key=True)
+        name: str
+
+        class Meta:
+            global_key_prefix = key_prefix
+            database = redis
+
+    await Migrator().run()
+
+    instance = ModelWithCustomPK(x=42, name="test")
+
+    # pk should return the actual value, not an ExpressionProxy
+    assert instance.pk == 42
+    assert not isinstance(instance.pk, ExpressionProxy)
+
+    # The custom field should also work for queries
+    await instance.save()
+    retrieved = await ModelWithCustomPK.get(42)
+    assert retrieved.pk == 42
+    assert retrieved.x == 42
+    assert retrieved.name == "test"


### PR DESCRIPTION
## Summary

Fixes #570 - When using a custom primary key field (e.g., `x: int = Field(primary_key=True)`), accessing `.pk` on an instance now correctly returns the actual value instead of an `ExpressionProxy` or auto-generated ULID.

## Changes

1. Added `PrimaryKeyAccessor` descriptor class that:
   - Returns the actual primary key value for instance-level access
   - Returns `ExpressionProxy` for class-level access (query building)
   - Handles setting the primary key value correctly

2. Modified `ModelMeta.__new__` to:
   - Detect when there's exactly one custom primary key (not `pk`)
   - Remove the default `pk` field from `model_fields`
   - Set up the `PrimaryKeyAccessor` descriptor for `.pk` access

3. Updated `validate_primary_key()` to safely handle cases where `pk` was already removed

## Example

```python
class Member(HashModel, index=True):
    x: int = Field(primary_key=True)
    name: str

member = Member(x=42, name="Test")
print(member.pk)  # Now correctly prints: 42 (was: ExpressionProxy before fix)
print(member.x)   # Prints: 42

# Class-level access still works for queries
await Member.find(Member.pk == 42).all()
```

## Testing

- Added tests for both HashModel and JsonModel
- All 226 existing tests pass
