### PR TITLE
Prevent EmbeddedJsonModel from generating primary keys

### DIFF
--- a/redis_om/__init__.py
+++ b/redis_om/__init__.py
@@ -19,6 +19,7 @@ from .model.model import (
 )
 from .model.types import Coordinates, GeoFilter
 
+
 # Backward compatibility alias - deprecated, use SchemaDetector or SchemaMigrator
 Migrator = SchemaDetector
 

--- a/tests/test_json_model.py
+++ b/tests/test_json_model.py
@@ -892,6 +892,9 @@ async def test_schema(m, key_prefix):
     # We need to build the key prefix because it will differ based on whether
     # these tests were copied into the tests_sync folder and unasynce'd.
     key_prefix = m.Member.make_key(m.Member._meta.primary_key_pattern.format(pk=""))
+    # Note: EmbeddedJsonModel pk fields are not included in the schema since
+    # embedded models don't need primary keys (they're stored as part of their
+    # parent document, not as separate Redis keys). See GitHub issue #496.
     assert m.Member.redisearch_schema() == (
         f"ON JSON PREFIX 1 {key_prefix} SCHEMA "
         "$.pk AS pk TAG SEPARATOR | "
@@ -901,13 +904,9 @@ async def test_schema(m, key_prefix):
         "$.age AS age NUMERIC "
         "$.bio AS bio TAG SEPARATOR | "
         "$.bio AS bio_fts TEXT "
-        "$.address.pk AS address_pk TAG SEPARATOR | "
         "$.address.city AS address_city TAG SEPARATOR | "
         "$.address.postal_code AS address_postal_code TAG SEPARATOR | "
-        "$.address.note.pk AS address_note_pk TAG SEPARATOR | "
         "$.address.note.description AS address_note_description TAG SEPARATOR | "
-        "$.orders[*].pk AS orders_pk TAG SEPARATOR | "
-        "$.orders[*].items[*].pk AS orders_items_pk TAG SEPARATOR | "
         "$.orders[*].items[*].name AS orders_items_name TAG SEPARATOR |"
     )
 


### PR DESCRIPTION
## Summary

Fixes #496 - EmbeddedJsonModel was generating primary keys with ULIDs even though embedded models don't need them (they're stored as part of their parent document, not as separate Redis keys).

## Changes

1. **EmbeddedJsonModel.pk field**: Override to use `Field(default=None, exclude=True)` so pk is excluded from serialization
2. **validate_pk validator**: Skip pk generation for embedded models (return None)
3. **validate_primary_key**: Skip primary key validation for embedded models
4. **Metaclass**: Clear `_meta.primary_key` for embedded models
5. **Test update**: Updated `test_schema` to reflect that embedded model pk fields are no longer in the RediSearch schema

## Before

```python
from aredis_om import EmbeddedJsonModel

class Address(EmbeddedJsonModel):
    city: str

addr = Address(city="Portland")
print(addr.pk)  # 01KFXVST2B7R8ZWBDZN21KX24P (unwanted ULID)
print(addr.model_dump())  # {'pk': '01KFXVST2B7R8ZWBDZN21KX24P', 'city': 'Portland'}
```

## After

```python
from aredis_om import EmbeddedJsonModel

class Address(EmbeddedJsonModel):
    city: str

addr = Address(city="Portland")
print(addr.pk)  # None
print(addr.model_dump())  # {'city': 'Portland'}
```
