### PR TITLE
Add benchmark regression detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,3 +173,27 @@ jobs:
           # Output to both logs and step summary
           cat benchmark-table.txt
           cat benchmark-table.txt >> $GITHUB_STEP_SUMMARY
+      - name: Prepare for benchmark storage
+        run: |
+          # Save benchmark results outside the repo before stashing
+          cp benchmark-results.json /tmp/benchmark-results.json
+          # Stash changes from make sync to allow branch switching
+          git stash --include-untracked
+          # Restore the benchmark results
+          cp /tmp/benchmark-results.json benchmark-results.json
+      - name: Store benchmark result
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          tool: 'pytest'
+          output-file-path: benchmark-results.json
+          # Store benchmark data in gh-pages branch
+          gh-pages-branch: gh-pages
+          benchmark-data-dir-path: dev/bench
+          # Fail if performance regresses by more than 20%
+          alert-threshold: '120%'
+          fail-on-alert: true
+          # Comment on PR when regression detected
+          comment-on-alert: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          # Only push to gh-pages on main branch
+          auto-push: ${{ github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
## Summary

Adds benchmark regression detection to fail CI when performance degrades by more than 20%.

Uses [benchmark-action/github-action-benchmark](https://github.com/benchmark-action/github-action-benchmark) to:
- Store benchmark history in the `gh-pages` branch (under `dev/bench`)
- Compare PR benchmarks against the baseline from main
- Fail the build if any benchmark regresses by more than 20% (`alert-threshold: '120%'`)
- Comment on PRs when regression is detected
- Only update the baseline when merging to main

This is a follow-up to #798 which added the benchmark test suite.

## How it works

1. First merge to main establishes the baseline (stored in gh-pages branch)
2. Subsequent PRs are compared against this baseline
3. If any benchmark is >20% slower, the build fails and a comment is added to the PR
4. When PRs are merged to main, the baseline is updated
