### PR TITLE
Fix packaging bug: include generated sync code in wheel (v1.0.6)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "redis-om"
-version = "1.0.5"
+version = "1.0.6"
 description = "Object mappings, and more, for Redis."
 authors = [{ name = "Redis OSS", email = "oss@redis.com" }]
 maintainers = [{ name = "Redis OSS", email = "oss@redis.com" }]
@@ -81,11 +81,22 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["aredis_om", "redis_om"]
+# Include generated sync code (redis_om/) that is in .gitignore
+# These files are created by `make sync` before building
+artifacts = [
+    "redis_om/**/*",
+    "tests_sync/**/*",
+]
 
 [tool.hatch.build.targets.sdist]
 include = [
     "aredis_om/**/*",
     "redis_om/**/*",
+]
+# Include generated sync code (redis_om/) that is in .gitignore
+artifacts = [
+    "redis_om/**/*",
+    "tests_sync/**/*",
 ]
 
 


### PR DESCRIPTION
## Summary

Fixes the packaging bug in v1.0.5 where the `redis_om` (sync) module only contained `__init__.py` but no other files.

## Root Causes

1. **Hatchling respects `.gitignore` by default**: The `.gitignore` file has `redis_om/*` (with exceptions for placeholder files). When `make sync` generates the sync code during CI, hatchling excluded those files from the wheel because they're gitignored.

2. **`supports_hash_field_expiration()` bug**: The function checks `redis_lib.asyncio.Redis.hexpire` in both async and sync versions. The sync version should check `redis_lib.Redis.hexpire` instead.

## Changes

### `pyproject.toml`
Added `artifacts` option to include generated files that are in `.gitignore`:
```toml
[tool.hatch.build.targets.wheel]
artifacts = ["redis_om/**/*", "tests_sync/**/*"]

[tool.hatch.build.targets.sdist]
artifacts = ["redis_om/**/*", "tests_sync/**/*"]
```

### `make_sync.py`
Added post-processing to fix the `supports_hash_field_expiration()` function by replacing `redis_lib.asyncio.Redis` with `redis_lib.Redis` in the generated sync code.

## Verification

- Built wheel now includes all files in both `aredis_om/` and `redis_om/`
- All async and sync tests pass
- `supports_hash_field_expiration()` works correctly in both modules
