### PR TITLE
Stop benchmark report notifications

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,8 @@ jobs:
 
   benchmark:
     name: Benchmarks
+    # Disabled because benchmark timing reports were generating noisy notifications.
+    if: ${{ false }}
     needs: lint
     runs-on: ubuntu-latest
     timeout-minutes: 10


### PR DESCRIPTION
## Summary
- Disable the benchmark timing report job so it stops creating noisy notifications.
- Keep the named Benchmarks job present as a skipped check instead of removing it outright.

## Tests
- git diff --check -- .github/workflows/ci.yml
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml")'
- pre-commit codespell hook

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change; no application code, auth, or data paths are affected.
> 
> **Overview**
> The **Benchmarks** workflow job is turned off by adding `if: ${{ false }}`, so pytest benchmarks and the `benchmark-action/github-action-benchmark` reporting (artifacts, step summary, gh-pages updates, regression alerts) no longer run or notify.
> 
> The job definition is left in place so the check still appears as **skipped** rather than being removed from the workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3b656e3027c623dc4a45a59b48578ad353b0d18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->