### PR TITLE
Check Redis server before hash field TTL

### DIFF
--- a/aredis_om/model/model.py
+++ b/aredis_om/model/model.py
@@ -5,6 +5,7 @@ import json
 import logging
 import operator
 import struct
+import weakref
 from copy import copy
 from enum import Enum
 from functools import reduce
@@ -82,6 +83,7 @@ escaper = TokenEscaper()
 # Minimum redis-py version for hash field expiration support
 _HASH_FIELD_EXPIRATION_MIN_VERSION = (5, 1, 0)
 _HASH_FIELD_EXPIRATION_MIN_SERVER_VERSION = (7, 4)
+_HASH_FIELD_EXPIRATION_SUPPORT_CACHE = weakref.WeakKeyDictionary()
 
 
 async def supports_hash_field_expiration(conn) -> bool:
@@ -90,6 +92,9 @@ async def supports_hash_field_expiration(conn) -> bool:
 
     Hash field expiration (HEXPIRE, HTTL, HPERSIST, etc.) was added in redis-py 5.1.0
     and requires Redis server 7.4+.
+
+    The result is cached for each Redis client instance after successfully
+    reading the server version.
 
     Returns:
         True if redis-py >= 5.1.0, the client has the hexpire method, and the
@@ -105,9 +110,16 @@ async def supports_hash_field_expiration(conn) -> bool:
         ):
             return False
 
+        try:
+            return _HASH_FIELD_EXPIRATION_SUPPORT_CACHE[conn]
+        except KeyError:
+            pass
+
         server_version = (await conn.info("server"))["redis_version"]
         server_version_parts = tuple(int(x) for x in server_version.split(".")[:2])
-        return server_version_parts >= _HASH_FIELD_EXPIRATION_MIN_SERVER_VERSION
+        supported = server_version_parts >= _HASH_FIELD_EXPIRATION_MIN_SERVER_VERSION
+        _HASH_FIELD_EXPIRATION_SUPPORT_CACHE[conn] = supported
+        return supported
     except (RedisError, ValueError, TypeError, KeyError, AttributeError):
         return False
 

--- a/aredis_om/model/model.py
+++ b/aredis_om/model/model.py
@@ -59,7 +59,7 @@ else:
     UndefinedType = type(...)
 from redis.asyncio.client import Pipeline
 from redis.commands.json.path import Path
-from redis.exceptions import ResponseError
+from redis.exceptions import RedisError, ResponseError
 from typing_extensions import Protocol, Unpack, get_args, get_origin
 from ulid import ULID
 
@@ -81,28 +81,34 @@ escaper = TokenEscaper()
 
 # Minimum redis-py version for hash field expiration support
 _HASH_FIELD_EXPIRATION_MIN_VERSION = (5, 1, 0)
+_HASH_FIELD_EXPIRATION_MIN_SERVER_VERSION = (7, 4)
 
 
-def supports_hash_field_expiration() -> bool:
+async def supports_hash_field_expiration(conn) -> bool:
     """
-    Check if the installed redis-py version supports hash field expiration commands.
+    Check if the client and connected server support hash field expiration commands.
 
     Hash field expiration (HEXPIRE, HTTL, HPERSIST, etc.) was added in redis-py 5.1.0
     and requires Redis server 7.4+.
 
     Returns:
-        True if redis-py >= 5.1.0 and has the hexpire method, False otherwise.
+        True if redis-py >= 5.1.0, the client has the hexpire method, and the
+        connected Redis server is at least version 7.4. False otherwise.
     """
     try:
         import redis as redis_lib
 
         version_str = getattr(redis_lib, "__version__", "0.0.0")
         version_parts = tuple(int(x) for x in version_str.split(".")[:3])
-        if version_parts >= _HASH_FIELD_EXPIRATION_MIN_VERSION:
-            # Also check that the method actually exists
-            return hasattr(redis_lib.asyncio.Redis, "hexpire")
-        return False
-    except (ValueError, AttributeError):
+        if version_parts < _HASH_FIELD_EXPIRATION_MIN_VERSION or not hasattr(
+            redis_lib.asyncio.Redis, "hexpire"
+        ):
+            return False
+
+        server_version = (await conn.info("server"))["redis_version"]
+        server_version_parts = tuple(int(x) for x in server_version.split(".")[:2])
+        return server_version_parts >= _HASH_FIELD_EXPIRATION_MIN_SERVER_VERSION
+    except (RedisError, ValueError, TypeError, KeyError, AttributeError):
         return False
 
 
@@ -3162,7 +3168,8 @@ class HashModel(RedisModel, abc.ABC):
             # Note: TTL preservation is skipped when using pipelines because
             # pipeline commands return futures, not actual values
             preserved_ttls: Dict[str, int] = {}
-            if supports_hash_field_expiration() and not is_pipeline:
+            supports_field_expiration = await supports_hash_field_expiration(self.db())
+            if supports_field_expiration and not is_pipeline:
                 fields_to_check = [f for f in document.keys() if f != "pk"]
                 if fields_to_check:
                     current_ttls = await conn.httl(key, *fields_to_check)
@@ -3176,7 +3183,7 @@ class HashModel(RedisModel, abc.ABC):
             # Apply field expirations after HSET (requires Redis 7.4+)
             # When using pipelines, we can still apply default expirations but
             # can't preserve manually-set TTLs
-            if supports_hash_field_expiration():
+            if supports_field_expiration:
                 for field_name in document.keys():
                     if field_name == "pk":
                         continue
@@ -3421,12 +3428,12 @@ class HashModel(RedisModel, abc.ABC):
         Raises:
             NotImplementedError: If redis-py version doesn't support HEXPIRE.
         """
-        if not supports_hash_field_expiration():
+        db = self.db()
+        if not await supports_hash_field_expiration(db):
             raise NotImplementedError(
                 "Hash field expiration requires redis-py >= 5.1.0 and Redis 7.4+"
             )
 
-        db = self.db()
         key = self.key()
         result = await db.hexpire(key, seconds, field_name, nx=nx, xx=xx, gt=gt, lt=lt)
         # hexpire returns a list of results, one per field
@@ -3447,12 +3454,12 @@ class HashModel(RedisModel, abc.ABC):
         Raises:
             NotImplementedError: If redis-py version doesn't support HTTL.
         """
-        if not supports_hash_field_expiration():
+        db = self.db()
+        if not await supports_hash_field_expiration(db):
             raise NotImplementedError(
                 "Hash field expiration requires redis-py >= 5.1.0 and Redis 7.4+"
             )
 
-        db = self.db()
         key = self.key()
         result = await db.httl(key, field_name)
         # httl returns a list of results, one per field
@@ -3473,12 +3480,12 @@ class HashModel(RedisModel, abc.ABC):
         Raises:
             NotImplementedError: If redis-py version doesn't support HPERSIST.
         """
-        if not supports_hash_field_expiration():
+        db = self.db()
+        if not await supports_hash_field_expiration(db):
             raise NotImplementedError(
                 "Hash field expiration requires redis-py >= 5.1.0 and Redis 7.4+"
             )
 
-        db = self.db()
         key = self.key()
         result = await db.hpersist(key, field_name)
         # hpersist returns a list of results, one per field

--- a/tests/test_hash_field_expiration.py
+++ b/tests/test_hash_field_expiration.py
@@ -239,13 +239,12 @@ async def test_hexpire_not_available_raises_or_warns(models, redis):
 
 
 @py_test_mark_asyncio
-async def test_check_hash_field_expiration_support():
+async def test_check_hash_field_expiration_support(redis):
     """Test utility function to check if hash field expiration is supported."""
     from aredis_om.model.model import supports_hash_field_expiration
 
-    # This should return True for redis-py >= 5.1.0
-    # The actual value depends on installed redis-py version
-    result = supports_hash_field_expiration()
+    # The result depends on both the installed redis-py and Redis server versions.
+    result = await supports_hash_field_expiration(redis)
     assert isinstance(result, bool)
 
 

--- a/tests/test_hash_field_expiration_support.py
+++ b/tests/test_hash_field_expiration_support.py
@@ -1,0 +1,21 @@
+from unittest import mock
+
+import pytest
+
+from aredis_om.model.model import supports_hash_field_expiration
+
+from .conftest import py_test_mark_asyncio
+
+
+@py_test_mark_asyncio
+@pytest.mark.parametrize(
+    ("server_version", "expected"),
+    [("7.2.14", False), ("7.4.0", True), ("8.0.0", True)],
+)
+async def test_supports_hash_field_expiration_checks_server_version(
+    server_version, expected
+):
+    conn = mock.AsyncMock()
+    conn.info.return_value = {"redis_version": server_version}
+
+    assert await supports_hash_field_expiration(conn) is expected

--- a/tests/test_hash_field_expiration_support.py
+++ b/tests/test_hash_field_expiration_support.py
@@ -1,6 +1,7 @@
 from unittest import mock
 
 import pytest
+from redis.exceptions import RedisError
 
 from aredis_om.model.model import supports_hash_field_expiration
 
@@ -19,3 +20,33 @@ async def test_supports_hash_field_expiration_checks_server_version(
     conn.info.return_value = {"redis_version": server_version}
 
     assert await supports_hash_field_expiration(conn) is expected
+    assert await supports_hash_field_expiration(conn) is expected
+    conn.info.assert_called_once_with("server")
+
+
+@py_test_mark_asyncio
+async def test_supports_hash_field_expiration_does_not_share_cache_between_connections():
+    first_conn = mock.AsyncMock()
+    first_conn.info.return_value = {"redis_version": "7.4.0"}
+    second_conn = mock.AsyncMock()
+    second_conn.info.return_value = {"redis_version": "7.4.0"}
+
+    assert await supports_hash_field_expiration(first_conn) is True
+    assert await supports_hash_field_expiration(second_conn) is True
+
+    first_conn.info.assert_called_once_with("server")
+    second_conn.info.assert_called_once_with("server")
+
+
+@py_test_mark_asyncio
+async def test_supports_hash_field_expiration_retries_after_info_error():
+    conn = mock.AsyncMock()
+    conn.info.side_effect = [
+        RedisError("temporary failure"),
+        {"redis_version": "7.4.0"},
+    ]
+
+    assert await supports_hash_field_expiration(conn) is False
+    assert await supports_hash_field_expiration(conn) is True
+    assert await supports_hash_field_expiration(conn) is True
+    assert conn.info.call_count == 2


### PR DESCRIPTION
Fixes #829

## Summary
Check the connected Redis server version before using hash field expiration commands. This prevents `HashModel.save()` from calling `HTTL` on Redis versions older than 7.4.

Added regression tests for supported and unsupported server versions.

## Testing
- Verified the fix against Redis 7.2.14
- `pytest -q -n auto ./tests/ ./tests_sync/`

Fixes #829

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core HashModel save paths to call INFO once per client and alters the public async API of supports_hash_field_expiration; behavior on Redis &lt; 7.4 is safer but callers must await the helper.
> 
> **Overview**
> **Hash field expiration** (`HTTL` / `HEXPIRE` on `HashModel.save()` and related helpers) is now gated on the **connected Redis server version**, not only redis-py ≥ 5.1.0. That stops saves on servers like **7.2.x** from issuing unsupported commands (fixes #829).
> 
> `supports_hash_field_expiration` is **async**, takes the Redis **client**, runs `INFO server` when the library looks capable, treats **7.4+** as supported, and **caches the result per client** in a `weakref.WeakKeyDictionary`. Failed `INFO` calls are not cached so a later retry can succeed. `HashModel.save`, `expire_field`, `field_ttl`, and `persist_field` all **await** this check before using field TTL APIs.
> 
> Tests cover version thresholds (7.2 vs 7.4+), per-connection caching, and recovery after a transient `RedisError` on `INFO`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f018297f0149ac2c4f44508e5e668b10cb6d3237. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->