### PR TITLE
Preserve primary key when loading models

### DIFF
--- a/aredis_om/model/model.py
+++ b/aredis_om/model/model.py
@@ -3232,7 +3232,8 @@ class HashModel(RedisModel, abc.ABC):
             document = convert_base64_to_bytes(document, cls.model_fields)
             # Convert bytes back to list[float] for vector fields
             document = convert_bytes_to_vector(document, cls.model_fields)
-            result = cls.model_validate(document)
+            document_with_pk = {**document, cls._meta.primary_key.name: pk}
+            result = cls.model_validate(document_with_pk)
         except TypeError as e:
             log.warning(
                 f'Could not parse Redis response. Error was: "{e}". Probably, the '
@@ -3249,6 +3250,7 @@ class HashModel(RedisModel, abc.ABC):
             document = convert_base64_to_bytes(document, cls.model_fields)
             # Convert bytes back to list[float] for vector fields
             document = convert_bytes_to_vector(document, cls.model_fields)
+            document[cls._meta.primary_key.name] = pk
             result = cls.model_validate(document)
         return result
 
@@ -3587,6 +3589,7 @@ class JsonModel(RedisModel, abc.ABC):
         document_data = await cls.db().json().get(cls.make_key(pk))
         if document_data is None:
             raise NotFoundError
+        document_data[cls._meta.primary_key.name] = pk
         # Convert timestamps back to datetime objects before validation
         document_data = convert_timestamp_to_datetime(document_data, cls.model_fields)
         # Convert base64 strings back to bytes for bytes fields

--- a/tests/test_primary_key_loading.py
+++ b/tests/test_primary_key_loading.py
@@ -1,0 +1,75 @@
+from unittest import mock
+
+from aredis_om import Field, HashModel, JsonModel
+
+from .conftest import py_test_mark_asyncio
+
+
+@py_test_mark_asyncio
+async def test_hash_model_get_uses_requested_pk_when_document_pk_is_missing():
+    fake_db = mock.AsyncMock()
+    fake_db.hgetall.return_value = {"name": "legacy"}
+
+    class LegacyModel(HashModel, index=True):
+        name: str
+
+        class Meta:
+            database = fake_db
+
+    model = await LegacyModel.get("existing-pk")
+
+    assert model.pk == "existing-pk"
+
+
+@py_test_mark_asyncio
+async def test_hash_model_get_decodes_bytes_before_adding_requested_pk():
+    fake_db = mock.AsyncMock()
+    fake_db.hgetall.return_value = {b"name": b"legacy"}
+
+    class LegacyModel(HashModel, index=True):
+        name: str
+
+        class Meta:
+            database = fake_db
+
+    model = await LegacyModel.get("existing-pk")
+
+    assert model.pk == "existing-pk"
+    assert model.name == "legacy"
+
+
+@py_test_mark_asyncio
+async def test_json_model_get_uses_requested_pk_when_document_pk_is_missing():
+    json_client = mock.Mock()
+    json_client.get = mock.AsyncMock(return_value={"name": "legacy"})
+    fake_db = mock.Mock()
+    fake_db.json.return_value = json_client
+    fake_db.execute_command.return_value = [object()]
+
+    class LegacyModel(JsonModel, index=True):
+        name: str
+
+        class Meta:
+            database = fake_db
+
+    model = await LegacyModel.get("existing-pk")
+
+    assert model.pk == "existing-pk"
+
+
+@py_test_mark_asyncio
+async def test_get_uses_configured_custom_primary_key():
+    fake_db = mock.AsyncMock()
+    fake_db.hgetall.return_value = {"name": "legacy"}
+
+    class LegacyModel(HashModel, index=True):
+        external_id: int = Field(primary_key=True)
+        name: str
+
+        class Meta:
+            database = fake_db
+
+    model = await LegacyModel.get(42)
+
+    assert model.pk == 42
+    assert model.external_id == 42


### PR DESCRIPTION
Fixes #828

## Summary
Preserve the requested primary key when loading HashModel and JsonModel records with a missing stored primary key.

Added tests for default and custom primary keys.

## Testing
- `pytest -q tests/test_primary_key_loading.py tests_sync/test_primary_key_loading.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, read-path change in `get()` with focused tests; behavior only affects records missing a stored PK and should not alter keys that already include one.
> 
> **Overview**
> **`HashModel.get` and `JsonModel.get` now inject the lookup key into the document before Pydantic validation** when Redis returns a record without a stored primary key field (common for legacy data).
> 
> The primary key field name comes from `cls._meta.primary_key.name`, so default `pk` and custom `Field(primary_key=True)` fields both resolve correctly. The HashModel byte-decode fallback path sets the same field after decoding.
> 
> New async tests cover missing stored PK for hash and JSON models, bytes responses, and a custom primary key.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 010fa7b3c6821e0b3274d8e4a580a91702e411b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->