### PR TITLE
Optimize FindQuery.update() with partial writes

### DIFF
--- a/aredis_om/model/model.py
+++ b/aredis_om/model/model.py
@@ -2032,7 +2032,7 @@ class FindQuery:
             if index == len(parts) - 1:
                 return field
 
-            annotation = getattr(field, "annotation", None)
+            annotation = field.annotation if PYDANTIC_V2 else field.outer_type_
             nested_model = next(
                 (
                     candidate
@@ -2061,7 +2061,8 @@ class FindQuery:
         for field_name in field_values:
             field = self._get_update_field(field_name)
             field_info = field if PYDANTIC_V2 else field.field_info
-            field_definitions[field_name] = (field.annotation, field_info)
+            annotation = field.annotation if PYDANTIC_V2 else field.outer_type_
+            field_definitions[field_name] = (annotation, field_info)
 
         update_model = create_model(  # type: ignore[call-overload]
             f"{self.model.__name__}Update", **field_definitions
@@ -2122,6 +2123,25 @@ class FindQuery:
 
         return keys
 
+    async def _get_preserved_hash_field_ttls(
+        self, keys: List[Union[str, bytes]], field_names: List[str]
+    ) -> Dict[Union[str, bytes], Dict[str, int]]:
+        """Return positive TTLs for HashModel fields that will be updated."""
+        if not field_names or not supports_hash_field_expiration():
+            return {}
+
+        ttl_pipeline = self.model.db().pipeline(transaction=False)
+        for key in keys:
+            ttl_pipeline.httl(key, *field_names)
+
+        ttl_results = await ttl_pipeline.execute()
+        return {
+            key: {
+                field_name: ttl for field_name, ttl in zip(field_names, ttls) if ttl > 0
+            }
+            for key, ttls in zip(keys, ttl_results)
+        }
+
     async def update(self, use_transaction=True, **field_values) -> int:
         """
         Update models that match this query to the given field-value pairs.
@@ -2140,8 +2160,13 @@ class FindQuery:
 
         pipeline = self.model.db().pipeline(transaction=use_transaction)
         if issubclass(self.model, HashModel):
+            preserved_ttls = await self._get_preserved_hash_field_ttls(
+                keys, list(serialized_values)
+            )
             for key in keys:
                 pipeline.hset(key, mapping=serialized_values)
+                for field_name, ttl in preserved_ttls.get(key, {}).items():
+                    pipeline.hexpire(key, ttl, field_name)
         else:
             for key in keys:
                 for field, value in serialized_values.items():

--- a/aredis_om/model/model.py
+++ b/aredis_om/model/model.py
@@ -2038,7 +2038,10 @@ class FindQuery:
                     candidate
                     for candidate in (annotation, *get_args(annotation))
                     if isinstance(candidate, type)
-                    and hasattr(candidate, "model_fields")
+                    and (
+                        hasattr(candidate, "model_fields")
+                        or hasattr(candidate, "__fields__")
+                    )
                 ),
                 None,
             )

--- a/aredis_om/model/model.py
+++ b/aredis_om/model/model.py
@@ -2174,6 +2174,9 @@ class FindQuery:
             The number of matching records updated.
         """
         serialized_values = self._serialize_update_values(field_values)
+        if not serialized_values:
+            return 0
+
         keys = await self._search_keys_only()
         if not keys:
             return 0

--- a/aredis_om/model/model.py
+++ b/aredis_om/model/model.py
@@ -2145,7 +2145,9 @@ class FindQuery:
         self, keys: List[Union[str, bytes]], field_names: List[str]
     ) -> Dict[Union[str, bytes], Dict[str, int]]:
         """Return positive TTLs for HashModel fields that will be updated."""
-        if not field_names or not supports_hash_field_expiration():
+        if not field_names:
+            return {}
+        if not await supports_hash_field_expiration(self.model.db()):
             return {}
 
         ttl_pipeline = self.model.db().pipeline(transaction=False)

--- a/aredis_om/model/model.py
+++ b/aredis_om/model/model.py
@@ -27,7 +27,7 @@ from typing import (
 from typing import get_args as typing_get_args
 
 from more_itertools import ichunked
-from pydantic import BaseModel
+from pydantic import BaseModel, create_model
 
 
 try:
@@ -978,6 +978,7 @@ class FindQuery:
             page_size=self.page_size,
             limit=self.limit,
             expressions=copy(self.expressions),
+            knn=self.knn,
             sort_fields=copy(self.sort_fields),
             projected_fields=copy(self.projected_fields),
             nocontent=self.nocontent,
@@ -2012,29 +2013,140 @@ class FindQuery:
             raise ValueError("only() requires at least one field name")
         return self.copy(projected_fields=list(fields))
 
-    async def update(self, use_transaction=True, **field_values):
+    def _get_update_field(self, field_name: str):
+        """Return the Pydantic field targeted by an update path."""
+        current_model = self.model
+        parts = field_name.split("__")
+
+        for index, part in enumerate(parts):
+            model_fields = getattr(current_model, "model_fields", None)
+            if model_fields is None:
+                model_fields = getattr(current_model, "__fields__", {})
+            if part not in model_fields:
+                raise QuerySyntaxError(
+                    f"The field {field_name} does not exist on the model "
+                    f"{self.model.__name__}"
+                )
+
+            field = model_fields[part]
+            if index == len(parts) - 1:
+                return field
+
+            annotation = getattr(field, "annotation", None)
+            nested_model = next(
+                (
+                    candidate
+                    for candidate in (annotation, *get_args(annotation))
+                    if isinstance(candidate, type)
+                    and hasattr(candidate, "model_fields")
+                ),
+                None,
+            )
+            if nested_model is None:
+                raise QuerySyntaxError(
+                    f"The update path {field_name} does not contain a nested model "
+                    f"at {part}"
+                )
+            current_model = nested_model
+
+        raise QuerySyntaxError(f"The update path {field_name} is empty")
+
+    def _validated_update_values(self, field_values: Dict[str, Any]):
+        """Validate update values once using the target fields' constraints."""
+        validate_model_fields(self.model, field_values)
+        field_definitions: Dict[str, Any] = {}
+        for field_name in field_values:
+            field = self._get_update_field(field_name)
+            field_info = field if PYDANTIC_V2 else field.field_info
+            field_definitions[field_name] = (field.annotation, field_info)
+
+        update_model = create_model(  # type: ignore[call-overload]
+            f"{self.model.__name__}Update", **field_definitions
+        )
+        if PYDANTIC_V2:
+            return update_model.model_validate(field_values).model_dump()
+        return update_model.parse_obj(field_values).dict()
+
+    def _serialize_update_values(self, field_values: Dict[str, Any]) -> Dict[str, Any]:
+        """Validate and encode values using the storage model's conventions."""
+        validated_values = self._validated_update_values(field_values)
+
+        if issubclass(self.model, HashModel):
+            document = convert_datetime_to_timestamp(validated_values)
+            model_fields = getattr(self.model, "model_fields", None)
+            if model_fields is None:
+                model_fields = getattr(self.model, "__fields__", {})
+            document = convert_vector_to_bytes(document, model_fields)
+            document = convert_bytes_to_base64(document)
+            document = jsonable_encoder(document)
+            document = {
+                key: value for key, value in document.items() if value is not None
+            }
+            return {
+                key: ("1" if value else "0") if isinstance(value, bool) else value
+                for key, value in document.items()
+            }
+
+        document = convert_datetime_to_timestamp(validated_values)
+        document = convert_bytes_to_base64(document)
+        return jsonable_encoder(document)
+
+    async def _search_keys_only(self) -> List[Union[str, bytes]]:
+        """Return all matching Redis keys without loading document contents."""
+        query = self.copy(
+            limit=self.page_size,
+            nocontent=True,
+            projected_fields=[],
+            return_as_dict=False,
+        )
+        keys: List[Union[str, bytes]] = []
+
+        while True:
+            raw_result = await query.execute(
+                exhaust_results=False,
+                return_raw_result=True,
+            )
+            if not raw_result:
+                break
+
+            count = raw_result[0]
+            page_keys = raw_result[1:]
+            keys.extend(page_keys)
+            if not page_keys or query.offset + len(page_keys) >= count:
+                break
+
+            query = query.copy(offset=query.offset + len(page_keys))
+
+        return keys
+
+    async def update(self, use_transaction=True, **field_values) -> int:
         """
         Update models that match this query to the given field-value pairs.
 
         Keys and values given as keyword arguments are interpreted as fields
         on the target model and the values as the values to which to set the
         given fields.
+
+        Returns:
+            The number of matching records updated.
         """
-        validate_model_fields(self.model, field_values)
-        pipeline = await self.model.db().pipeline() if use_transaction else None
+        serialized_values = self._serialize_update_values(field_values)
+        keys = await self._search_keys_only()
+        if not keys:
+            return 0
 
-        # TODO: async for here?
-        for model in await self.all():
-            for field, value in field_values.items():
-                setattr(model, field, value)
-            # TODO: In the non-transaction case, can we do more to detect
-            #  failure responses from Redis?
-            await model.save(pipeline=pipeline)
+        pipeline = self.model.db().pipeline(transaction=use_transaction)
+        if issubclass(self.model, HashModel):
+            for key in keys:
+                pipeline.hset(key, mapping=serialized_values)
+        else:
+            for key in keys:
+                for field, value in serialized_values.items():
+                    path = "$." + field.replace("__", ".")
+                    pipeline.json().set(key, path, value)
 
-        if pipeline:
-            # TODO: Response type?
-            # TODO: Better error detection for transactions.
-            await pipeline.execute()
+        await pipeline.execute()
+        return len(keys)
 
     async def delete(self):
         """Delete all matching records in this query."""

--- a/docs/querying.md
+++ b/docs/querying.md
@@ -306,9 +306,10 @@ Update all matching records with new field values:
 
 ```python
 # Give everyone in the "premium" tier a discount
-await Customer.find(
+updated_count = await Customer.find(
     Customer.tier == "premium"
 ).update(discount_percent=20)
+# `updated_count` is the number of matching records updated.
 ```
 
 ### `.delete()` - Delete Multiple Records

--- a/tests/test_find_query_update.py
+++ b/tests/test_find_query_update.py
@@ -1,6 +1,6 @@
 import abc
 from types import SimpleNamespace
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 import pytest
 from pydantic import ValidationError
@@ -71,6 +71,14 @@ def hash_model(database):
         status: str
         age: int = Field(ge=0)
         payload: str
+
+    User.Meta.database = database
+    return User
+
+
+def nullable_hash_model(database):
+    class User(HashModel, abc.ABC, index=True):
+        nickname: Optional[str] = None
 
     User.Meta.database = database
     return User
@@ -151,6 +159,19 @@ async def test_query_update_validates_values_before_search(monkeypatch):
     with pytest.raises(ValidationError):
         await User.find().update(age=-1)
 
+    assert database.search_calls == []
+    assert database.pipelines == []
+
+
+@py_test_mark_asyncio
+async def test_query_update_skips_empty_hash_mapping(monkeypatch):
+    enable_search(monkeypatch)
+    database = FakeDatabase({0: [1, "user:1"]})
+    User = nullable_hash_model(database)
+
+    updated = await User.find().update(nickname=None)
+
+    assert updated == 0
     assert database.search_calls == []
     assert database.pipelines == []
 

--- a/tests/test_find_query_update.py
+++ b/tests/test_find_query_update.py
@@ -55,6 +55,7 @@ class FakeDatabase:
 
 def enable_search(monkeypatch):
     monkeypatch.setattr(model_module, "has_redisearch", lambda db: True)
+    monkeypatch.setattr(model_module, "supports_hash_field_expiration", lambda: False)
 
 
 def hash_model(database):
@@ -87,6 +88,25 @@ def test_query_update_resolves_pydantic_v1_nested_models():
     class RootModel:
         model_fields = {"address": SimpleNamespace(annotation=LegacyNestedModel)}
 
+    query = object.__new__(model_module.FindQuery)
+    query.model = RootModel
+
+    assert (
+        query._get_update_field("address__city") is LegacyNestedModel.__fields__["city"]
+    )
+
+
+def test_query_update_resolves_pydantic_v1_field_types(monkeypatch):
+    class LegacyNestedModel:
+        __fields__ = {"city": object()}
+
+    class LegacyField:
+        outer_type_ = LegacyNestedModel
+
+    class RootModel:
+        __fields__ = {"address": LegacyField()}
+
+    monkeypatch.setattr(model_module, "PYDANTIC_V2", False)
     query = object.__new__(model_module.FindQuery)
     query.model = RootModel
 

--- a/tests/test_find_query_update.py
+++ b/tests/test_find_query_update.py
@@ -1,4 +1,5 @@
 import abc
+from types import SimpleNamespace
 from typing import Any, Dict, List
 
 import pytest
@@ -77,6 +78,21 @@ def json_model(database):
 
     Document.Meta.database = database
     return Document
+
+
+def test_query_update_resolves_pydantic_v1_nested_models():
+    class LegacyNestedModel:
+        __fields__ = {"city": object()}
+
+    class RootModel:
+        model_fields = {"address": SimpleNamespace(annotation=LegacyNestedModel)}
+
+    query = object.__new__(model_module.FindQuery)
+    query.model = RootModel
+
+    assert (
+        query._get_update_field("address__city") is LegacyNestedModel.__fields__["city"]
+    )
 
 
 @py_test_mark_asyncio

--- a/tests/test_find_query_update.py
+++ b/tests/test_find_query_update.py
@@ -55,7 +55,15 @@ class FakeDatabase:
 
 def enable_search(monkeypatch):
     monkeypatch.setattr(model_module, "has_redisearch", lambda db: True)
-    monkeypatch.setattr(model_module, "supports_hash_field_expiration", lambda: False)
+
+    async def field_expiration_is_unsupported(_conn):
+        return False
+
+    monkeypatch.setattr(
+        model_module,
+        "supports_hash_field_expiration",
+        field_expiration_is_unsupported,
+    )
 
 
 def hash_model(database):

--- a/tests/test_find_query_update.py
+++ b/tests/test_find_query_update.py
@@ -1,0 +1,164 @@
+from typing import Any, Dict, List
+
+import pytest
+from pydantic import ValidationError
+
+from aredis_om import EmbeddedJsonModel, Field, HashModel, JsonModel
+from aredis_om.model import model as model_module
+
+from .conftest import py_test_mark_asyncio
+
+
+class FakePipeline:
+    def __init__(self):
+        self.hash_updates: List[tuple[str, Dict[str, Any]]] = []
+        self.json_updates: List[tuple[str, str, Any]] = []
+        self.execute_count = 0
+
+    def hset(self, key: str, mapping: Dict[str, Any]):
+        self.hash_updates.append((key, mapping))
+        return self
+
+    def json(self):
+        return self
+
+    def set(self, key: str, path: str, value: Any):
+        self.json_updates.append((key, path, value))
+        return self
+
+    async def execute(self):
+        self.execute_count += 1
+        return []
+
+
+class FakeDatabase:
+    def __init__(self, search_results: Dict[int, List[Any]]):
+        self.search_results = search_results
+        self.search_calls: List[tuple[Any, ...]] = []
+        self.pipelines: List[FakePipeline] = []
+        self.pipeline_transactions: List[bool] = []
+
+    async def execute_command(self, *args):
+        self.search_calls.append(args)
+        limit_index = args.index("LIMIT")
+        offset = args[limit_index + 1]
+        return self.search_results[offset]
+
+    def pipeline(self, transaction: bool = True):
+        self.pipeline_transactions.append(transaction)
+        pipeline = FakePipeline()
+        self.pipelines.append(pipeline)
+        return pipeline
+
+
+def enable_search(monkeypatch):
+    monkeypatch.setattr(model_module, "has_redisearch", lambda db: True)
+
+
+def hash_model(database):
+    class User(HashModel, index=True):
+        status: str
+        age: int = Field(ge=0)
+        payload: str
+
+    User.Meta.database = database
+    return User
+
+
+def json_model(database):
+    class Address(EmbeddedJsonModel):
+        city: str
+
+    class Document(JsonModel, index=True):
+        address: Address
+        status: str
+        payload: Dict[str, str]
+
+    Document.Meta.database = database
+    return Document
+
+
+@py_test_mark_asyncio
+async def test_query_update_uses_key_only_search_and_partial_hset(monkeypatch):
+    enable_search(monkeypatch)
+    database = FakeDatabase({0: [2, "user:1", "user:2"]})
+    User = hash_model(database)
+
+    updated = await User.find().only("status").update(status="active", age="42")
+
+    assert updated == 2
+    assert database.search_calls[0][-1] == "NOCONTENT"
+    assert all("RETURN" not in call for call in database.search_calls)
+    assert database.pipeline_transactions == [True]
+    assert database.pipelines[0].hash_updates == [
+        ("user:1", {"status": "active", "age": 42}),
+        ("user:2", {"status": "active", "age": 42}),
+    ]
+    assert database.pipelines[0].execute_count == 1
+
+
+@py_test_mark_asyncio
+async def test_query_update_validates_values_before_search(monkeypatch):
+    enable_search(monkeypatch)
+    database = FakeDatabase({0: [1, "user:1"]})
+    User = hash_model(database)
+
+    with pytest.raises(ValidationError):
+        await User.find().update(age=-1)
+
+    assert database.search_calls == []
+    assert database.pipelines == []
+
+
+@py_test_mark_asyncio
+async def test_query_update_paginates_key_only_results(monkeypatch):
+    enable_search(monkeypatch)
+    database = FakeDatabase(
+        {
+            0: [3, "user:1"],
+            1: [3, "user:2"],
+            2: [3, "user:3"],
+        }
+    )
+    User = hash_model(database)
+
+    query = User.find()
+    query.page_size = 1
+    query.limit = 1
+    updated = await query.update(status="active")
+
+    assert updated == 3
+    assert [call[call.index("LIMIT") + 1] for call in database.search_calls] == [
+        0,
+        1,
+        2,
+    ]
+    assert len(database.pipelines[0].hash_updates) == 3
+
+
+@py_test_mark_asyncio
+async def test_query_update_uses_json_paths_and_non_transactional_pipeline(monkeypatch):
+    enable_search(monkeypatch)
+    database = FakeDatabase({0: [1, "document:1"]})
+    Document = json_model(database)
+
+    updated = await Document.find().update(use_transaction=False, status="active")
+
+    assert updated == 1
+    assert database.pipeline_transactions == [False]
+    assert database.pipelines[0].json_updates == [("document:1", "$.status", "active")]
+    assert database.pipelines[0].execute_count == 1
+
+
+@py_test_mark_asyncio
+async def test_query_update_uses_nested_json_path(monkeypatch):
+    enable_search(monkeypatch)
+    database = FakeDatabase({0: [1, "document:1"]})
+    Document = json_model(database)
+
+    updated = await Document.find().update(address__city="Seoul")
+
+    assert updated == 1
+    assert database.pipelines[0].json_updates == [
+        ("document:1", "$.address.city", "Seoul")
+    ]

--- a/tests/test_find_query_update.py
+++ b/tests/test_find_query_update.py
@@ -1,3 +1,4 @@
+import abc
 from typing import Any, Dict, List
 
 import pytest
@@ -56,7 +57,7 @@ def enable_search(monkeypatch):
 
 
 def hash_model(database):
-    class User(HashModel, index=True):
+    class User(HashModel, abc.ABC, index=True):
         status: str
         age: int = Field(ge=0)
         payload: str
@@ -69,7 +70,7 @@ def json_model(database):
     class Address(EmbeddedJsonModel):
         city: str
 
-    class Document(JsonModel, index=True):
+    class Document(JsonModel, abc.ABC, index=True):
         address: Address
         status: str
         payload: Dict[str, str]

--- a/tests/test_hash_field_expiration.py
+++ b/tests/test_hash_field_expiration.py
@@ -281,6 +281,29 @@ async def test_update_preserves_field_expiration(models, redis):
 
 
 @py_test_mark_asyncio
+async def test_find_query_update_preserves_updated_field_expiration(models, redis):
+    """FindQuery.update() should preserve the TTL of an updated hash field."""
+    session = models.Session(
+        user_id="user123",
+        token="abc123",
+        refresh_token="refresh456",
+    )
+    await session.save()
+
+    initial_ttl = await session.field_ttl("token")
+    assert initial_ttl > 0
+
+    updated_count = await models.Session.find(models.Session.pk == session.pk).update(
+        token="updated-token"
+    )
+
+    assert updated_count == 1
+    updated_ttl = await session.field_ttl("token")
+    assert updated_ttl > 0
+    assert updated_ttl <= initial_ttl
+
+
+@py_test_mark_asyncio
 async def test_save_preserves_manually_set_ttl(models, redis):
     """
     Calling save() should not overwrite a manually-set TTL with the default.


### PR DESCRIPTION
## Summary

Implements #777 by updating matching records without materializing full Pydantic models.

## What changed

- Uses `FT.SEARCH ... NOCONTENT` to collect matching keys page by page.
- Validates and serializes update values once, including Pydantic constraints and Redis OM storage conversions.
- Uses partial `HSET` mappings for `HashModel`.
- Uses path-level `JSON.SET` commands for `JsonModel`, including nested `__` paths.
- Preserves the `use_transaction` flag and returns the number of updated records.
- Keeps query projections out of the key-only search and preserves KNN state when copying queries.
- Documents the new return value.

## Testing

- `pytest -q tests --ignore tests/test_benchmarks.py`: 265 passed.
- `pytest -q tests/test_hash_model.py tests/test_json_model.py`: 147 passed.
- Generated sync tests for the new coverage plus Hash/JSON model tests: 157 passed.
- `ruff check` and `ruff format --check` on changed source/tests.
- `python -m compileall -q aredis_om tests`.
- `bandit -q -r aredis_om/model/model.py -s B608`.

Redis Stack was run locally via Docker Compose for the integration tests; benchmark tests were excluded from the full run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Bulk updates now bypass per-instance `save()` and use direct Redis writes, so behavior depends on the new serialization/validation path and pipeline semantics; hash field TTL preservation adds extra Redis calls on supported servers.
> 
> **Overview**
> **`FindQuery.update()`** no longer loads full models and calls `save()` per match. It validates and serializes kwargs once, pages **`FT.SEARCH` with `NOCONTENT`** to collect keys (ignoring `.only()` projections), then applies **partial `HSET` mappings** for `HashModel` or **`JSON.SET`** on `$.` paths (including `__` nested paths) for `JsonModel` in a pipeline. **`use_transaction`** is honored, **`FindQuery.dict()`** now copies **`knn`**, and the method **returns the number of updated records** (0 when nothing matches or Hash updates would be empty).
> 
> Hash bulk updates **re-apply `HEXPIRE`** for updated fields when Redis 7.4+ field TTLs were set. Docs show the return value; new unit and integration tests cover validation, pagination, JSON paths, and TTL preservation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0363c8a25c48c91defab69edab4ecd9038e8d49a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->