### PR TITLE
Support chaining FindQuery filters

### DIFF
--- a/aredis_om/model/model.py
+++ b/aredis_om/model/model.py
@@ -1975,6 +1975,13 @@ class FindQuery:
             exhaust_results=False
         )
 
+    def find(self, *expressions: ExpressionOrNegated):
+        """Return a query with additional expressions combined using AND."""
+        return self.copy(
+            expressions=[*self.expressions, *expressions],
+            knn=self.knn,
+        )
+
     def sort_by(self, *fields: str):
         if not fields:
             return self

--- a/docs/querying.md
+++ b/docs/querying.md
@@ -40,6 +40,11 @@ customers = await Customer.find(
     Customer.last_name == "Brookins",
     Customer.age > 30
 ).all()
+
+# Build dynamic filters incrementally (also combined with AND)
+query = Customer.find(Customer.last_name == "Brookins")
+query = query.find(Customer.age > 30)
+customers = await query.all()
 ```
 
 ## Expression Operators

--- a/tests/test_find_query.py
+++ b/tests/test_find_query.py
@@ -446,3 +446,19 @@ async def test_find_query_monster(m):
         1,
         1,
     ]
+
+
+@py_test_mark_asyncio
+async def test_find_query_supports_chaining(members, m):
+    member1, member2, member3 = members
+
+    base_query = m.Member.find(m.Member.last_name == "Brookins")
+    query = base_query.find(m.Member.age > 35)
+    actual = await query.sort_by("age").all()
+
+    assert actual == [member1]
+    assert await base_query.sort_by("age").all() == [member2, member1]
+
+    query = m.Member.find().find(m.Member.first_name == "Andrew")
+    query = query.find(m.Member.age > 50)
+    assert await query.all() == [member3]


### PR DESCRIPTION
## Summary

Implements #780 by allowing `FindQuery` instances to accept additional filter expressions through `.find()`.

## What changed

- Adds `FindQuery.find(*expressions)` and returns a new query, leaving the original unchanged.
- Appends expressions to the existing query so they use the same AND semantics as `Model.find(expr1, expr2)`.
- Preserves the query's KNN state when creating the chained query.
- Documents incremental filter construction.

## Testing

- `pytest -q tests/test_find_query.py tests_sync/test_find_query.py`: 52 passed.
- `pytest -q tests --ignore tests/test_benchmarks.py`: 261 passed.
- `pytest -q tests_sync --ignore tests_sync/test_benchmarks.py`: 261 passed.
- `ruff check` and `ruff format --check` on changed source/tests.
- `python -m compileall -q aredis_om tests`.
- `bandit -q -r aredis_om/model/model.py -s B608`.

Redis Stack was run locally through Docker Compose for the integration tests; benchmark tests were excluded from the full run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive query API on top of existing `FindQuery.copy()` behavior; covered by find-query tests with no auth or data-migration impact.
> 
> **Overview**
> **FindQuery** now supports **chaining filters** via a new `.find(*expressions)` method, so you can build queries step by step instead of passing every predicate into `Model.find()` up front.
> 
> Each call returns a **new** `FindQuery` (via `copy()`), appending expressions with the same **AND** semantics as `Model.find(expr1, expr2)`, and **preserves KNN** state on the chained query. Documentation in `querying.md` shows incremental construction; an async integration test verifies chaining, sorting, and that the original query object is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e0cac152f5d3125d20e921bffe9b369009777be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->