### PR TITLE
Allow pytest-asyncio 1.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ dev = [
     "pytest-cov>=5,<8",
     "pytest-xdist>=3.1.0",
     "unasync>=0.6.0",
-    "pytest-asyncio>=0.24,<1.4",
+    "pytest-asyncio>=0.24,<1.5",
     "email-validator>=2.0.0",
     "tox>=4.14.1",
     "tox-pyenv>=1.1.0",
@@ -123,4 +123,3 @@ lines-after-imports = 2
 [tool.mypy]
 ignore_missing_imports = true
 disable_error_code = ["annotation-unchecked"]
-

--- a/uv.lock
+++ b/uv.lock
@@ -2054,7 +2054,7 @@ dev = [
     { name = "mypy", marker = "platform_python_implementation == 'CPython'", specifier = ">=1.9.0" },
     { name = "pre-commit", marker = "python_full_version >= '3.10'", specifier = ">=4.3.0" },
     { name = "pytest", specifier = ">=8.0.2,<10.0.0" },
-    { name = "pytest-asyncio", specifier = ">=0.24,<1.4" },
+    { name = "pytest-asyncio", specifier = ">=0.24,<1.5" },
     { name = "pytest-benchmark", specifier = ">=5.2.3" },
     { name = "pytest-cov", specifier = ">=5,<8" },
     { name = "pytest-xdist", specifier = ">=3.1.0" },


### PR DESCRIPTION
Supersedes #837. Updates the development requirement and the corresponding uv.lock metadata.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only dependency constraint and lockfile metadata; no runtime or application code changes.
> 
> **Overview**
> Widens the **dev** dependency cap for `pytest-asyncio` from `<1.4` to `<1.5`, so installs can resolve **1.4.x** while staying below 1.5. **`uv.lock`** is updated to match the new specifier.
> 
> Also removes a stray blank line under **`[tool.mypy]`** in `pyproject.toml` (formatting only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b24cfac485d184708c7dd7ff53ed5632ec91d22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->