### PR TITLE
Upgrade Codecov action to v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,9 +88,9 @@ jobs:
           make test
           uv run coverage xml
       - name: Upload coverage
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
-          file: ./coverage.xml
+          files: ./coverage.xml
           flags: unit
           env_vars: OS
           fail_ci_if_error: false


### PR DESCRIPTION
Supersedes #822. Uses the v6 files input so coverage.xml is uploaded.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only dependency bump with a straightforward input rename; no application or security logic changes.
> 
> **Overview**
> Updates the unit-test **Upload coverage** step in CI to use `codecov/codecov-action@v6` instead of v5.
> 
> The coverage report path is passed with the v6 **`files`** input (`./coverage.xml`) in place of the deprecated **`file`** input. Upload flags and behavior (`flags: unit`, `env_vars: OS`, `fail_ci_if_error: false`) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d19c2be0c44accfe06586842d07d05823bacbe06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->